### PR TITLE
Easy integration in Ruby 2.0

### DIFF
--- a/lib/syck.rb
+++ b/lib/syck.rb
@@ -7,6 +7,7 @@
 #
 
 require 'yaml/syck'
+require File.expand_path('../yaml/engine_manager', __FILE__)
 
 # == YAML
 #

--- a/lib/yaml/engine_manager.rb
+++ b/lib/yaml/engine_manager.rb
@@ -1,0 +1,71 @@
+##
+# The YAML module allows you to use one of the two YAML engines that ship with
+# ruby.  By default Psych is used but the old and unmaintained Syck may be
+# chosen.
+#
+# See Psych or Syck for usage and documentation.
+#
+# To set the YAML engine to syck:
+#
+#   YAML::ENGINE.yamler = 'syck'
+#
+# To set the YAML engine back to psych:
+#
+#   YAML::ENGINE.yamler = 'psych'
+
+module YAML
+  class EngineManager # :nodoc:
+    attr_reader :yamler
+
+    def initialize
+      @yamler = nil
+    end
+
+    def syck?
+      'syck' == @yamler
+    end
+
+    def yamler= engine
+      raise(ArgumentError, "bad engine") unless %w{syck psych}.include?(engine)
+
+      require engine unless (engine == 'syck' ? Syck : Psych).const_defined?(:VERSION)
+
+      Object.class_eval <<-eorb, __FILE__, __LINE__ + 1
+        remove_const 'YAML'
+        YAML = #{engine.capitalize}
+        remove_method :to_yaml
+        alias :to_yaml :#{engine}_to_yaml
+      eorb
+
+      @yamler = engine
+      engine
+    end
+  end
+
+  ##
+  # Allows changing the current YAML engine.  See YAML for details.
+
+  remove_const :ENGINE
+  ENGINE = YAML::EngineManager.new
+end
+
+if defined?(Psych)
+  engine = 'psych'
+elsif defined?(Syck)
+  engine = 'syck'
+else
+  begin
+    require 'psych'
+    engine = 'psych'
+  rescue LoadError
+    warn "#{caller[0]}:"
+    warn "It seems your ruby installation is missing psych (for YAML output)."
+    warn "To eliminate this warning, please install libyaml and reinstall your ruby."
+    require 'syck'
+    engine = 'syck'
+  end
+end
+
+module Syck
+  ENGINE = YAML::ENGINE
+end

--- a/syck.gemspec
+++ b/syck.gemspec
@@ -3,7 +3,7 @@
 require 'time'
 Gem::Specification.new do |s|
   s.name = "syck"
-  s.version = "1.0.0.20130610191609"
+  s.version = "1.0.0.4"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Aaron Patterson", "Mat Brown"]


### PR DESCRIPTION
We're upgrading to Ruby 2.0, but need to keep using Syck for YAML as we have
a huge set of Syck-serialized data that Psych doesn't consistently parse the
way we expect. This pull request makes the syck gem a drop-in replacement for
Ruby 1.9.3's swappable YAML:
- A gemspec is included in the repository. I left the Hoe stuff in the Rakefile,
  but it's important that the native code is built when the gem is installed,
  not when the gem is packaged for release (that's what's going on
  [here](https://github.com/tenderlove/syck/issues/1)). Maintaining a gemspec
  by hand is pretty straightforward, and Rubygems takes care of the rest.
- I ported the `YAML::EngineManager` implementation from Ruby 1.9.3. So with
  this gem installed and loaded, you can simply run
  `YAML::ENGINE.yamler = 'syck'` just like in Ruby 1.9, and everything works.
