### PR TITLE
assignment Syck to YAML

### DIFF
--- a/lib/syck.rb
+++ b/lib/syck.rb
@@ -444,4 +444,4 @@ module Kernel
     private :y
 end
 
-
+YAML = Syck if defined?(YAML)


### PR DESCRIPTION
YAML::EngineManager is obsoleted now. see https://bugs.ruby-lang.org/issues/8344

Please bump version of Syck and release it version.
