### PR TITLE
Fixes syck compilation errors for ruby 2.6-r1

### DIFF
--- a/ext/syck/syck.h
+++ b/ext/syck/syck.h
@@ -17,7 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
-#include "ruby/st.h"
+#include "ruby/ruby.h"
 
 #if defined(__cplusplus)
 extern "C" {


### PR DESCRIPTION
This fixes a compilation error when we call bundle install using this syck gem with ruby 2.6-r1

We see the error ```/usr/local/include/ruby-2.6.0/ruby/st.h:146:52: error: unknown type name 'VALUE'``` when compiling syck.

The header fix in this pull request seems to compile with all known rubies; it has been tested with 2.5 and 2.6 and tests pass.

This header issue seems to have been introduced with ruby 2.6 at some point between preview 1 and preview 2; if that helps. I'm not sure if your tracking this on https://bugs.ruby-lang.org/ since this code was pulled out of ruby quite some time ago.
