### PR TITLE
Fix compilation on Ruby 3.0

### DIFF
--- a/ext/syck/rubyext.c
+++ b/ext/syck/rubyext.c
@@ -23,7 +23,7 @@ typedef struct RVALUE {
 #endif
     struct RBasic  basic;
     struct RObject object;
-    struct RClass  klass;
+    /*struct RClass  klass;*/
     /*struct RFloat  flonum;*/
     /*struct RString string;*/
     struct RArray  array;


### PR DESCRIPTION
Since about a week ago syck no longer compile on ruby-head, it fails with:

```
rubyext.c:26:20: error: field 'klass' has incomplete type
     struct RClass  klass;
                    ^
```

(as well as plenty of warnings).

This PR fixes the compilation, and as far as I can tell it work fine, even though I have to admit I'm not too sure what I'm doing.
