### PR TITLE
Undefine T_DATA allocators for Ruby 3.2 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: [ '3.0', 2.7, 2.6, 2.5, 2.4, head ]
+        ruby: ['3.1', '3.0', '2.7', '2.6', '2.5', '2.4', head ]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/ext/syck/rubyext.c
+++ b/ext/syck/rubyext.c
@@ -2231,6 +2231,7 @@ Init_syck()
      * Define YAML::Syck::Node class
      */
     cNode = rb_define_class_under( rb_syck, "Node", rb_cObject );
+    rb_undef_alloc_func(cNode);
     rb_undef( cNode, rb_intern("initialize_copy") );
     rb_define_attr( cNode, "emitter", 1, 1 );
     rb_define_attr( cNode, "resolver", 1, 1 );


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/18007

cc @hsbt @rafaelfranca @olleolleolle @tenderlove 