### PR TITLE
Fix crash during parsing

### DIFF
--- a/ext/syck/rubyext.c
+++ b/ext/syck/rubyext.c
@@ -649,7 +649,7 @@ rb_syck_load_handler(SyckParser *p, SyckNode *n)
     /*
      * Create node,
      */
-    obj = rb_funcall( resolver, s_node_import, 1, Data_Wrap_Struct( cNode, NULL, NULL, n ) );
+    obj = rb_funcall( resolver, s_node_import, 1, Data_Wrap_Struct( cNode, syck_node_mark, NULL, n ) );
 
     /*
      * ID already set, let's alter the symbol table to accept the new object


### PR DESCRIPTION
The following script causes a crash on my machine (Ruby 3.1.2 on macOS):

```ruby
require "syck"

GC.stress = true
GC.auto_compact = true

yaml = Syck::Parser.new
yaml.load(<<-YAML)
- foobar
YAML
```

Enabling compaction causes it to reliably crash, but I think it could also crash without compaction.