### PR TITLE
Add gram.y that generates gram.c

### DIFF
--- a/ext/syck/gram.c
+++ b/ext/syck/gram.c
@@ -1,12 +1,14 @@
-/* A Bison parser, made by GNU Bison 1.875d.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
-/* Skeleton parser for Yacc-like parsing with Bison,
-   Copyright (C) 1984, 1989, 1990, 2000, 2001, 2002, 2003, 2004 Free Software Foundation, Inc.
+/* Bison implementation for Yacc-like parsers in C
 
-   This program is free software; you can redistribute it and/or modify
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+   Inc.
+
+   This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2, or (at your option)
-   any later version.
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
 
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,17 +16,27 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 59 Temple Place - Suite 330,
-   Boston, MA 02111-1307, USA.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
-/* As a special exception, when this file is copied by Bison into a
-   Bison output file, you may use that output file without restriction.
-   This special exception was added by the Free Software Foundation
-   in version 1.24 of Bison.  */
+/* As a special exception, you may create a larger work that contains
+   part or all of the Bison parser skeleton and distribute that work
+   under terms of your choice, so long as that work isn't itself a
+   parser generator using the skeleton or a modified version thereof
+   as a parser skeleton.  Alternatively, if you modify or redistribute
+   the parser skeleton itself, you may (at your option) remove this
+   special exception, which will cause the skeleton and the resulting
+   Bison output files to be licensed under the GNU General Public
+   License without this special exception.
 
-/* Written by Richard Stallman by simplifying the original so called
-   ``semantic'' parser.  */
+   This special exception was added by the Free Software Foundation in
+   version 2.2 of Bison.  */
+
+/* C LALR(1) parser skeleton written by Richard Stallman, by
+   simplifying the original so-called "semantic" parser.  */
+
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
 
 /* All symbols defined below should begin with yy or YY, to avoid
    infringing on user name space.  This should be done even for local
@@ -33,8 +45,11 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
-/* Identify Bison output.  */
-#define YYBISON 1
+/* Identify Bison output, and Bison version.  */
+#define YYBISON 30802
+
+/* Bison version string.  */
+#define YYBISON_VERSION "3.8.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -42,66 +57,35 @@
 /* Pure parsers.  */
 #define YYPURE 1
 
-/* Using locations.  */
-#define YYLSP_NEEDED 0
+/* Push parsers.  */
+#define YYPUSH 0
 
-/* If NAME_PREFIX is specified substitute the variables and functions
-   names.  */
-#define yyparse syckparse
-#define yylex   sycklex
-#define yyerror syckerror
-#define yylval  sycklval
-#define yychar  syckchar
-#define yydebug syckdebug
-#define yynerrs sycknerrs
+/* Pull parsers.  */
+#define YYPULL 1
 
 
-/* Tokens.  */
-#ifndef YYTOKENTYPE
-# define YYTOKENTYPE
-   /* Put the tokens into the symbol table, so that GDB and other debuggers
-      know about them.  */
-   enum yytokentype {
-     YAML_ANCHOR = 258,
-     YAML_ALIAS = 259,
-     YAML_TRANSFER = 260,
-     YAML_TAGURI = 261,
-     YAML_ITRANSFER = 262,
-     YAML_WORD = 263,
-     YAML_PLAIN = 264,
-     YAML_BLOCK = 265,
-     YAML_DOCSEP = 266,
-     YAML_IOPEN = 267,
-     YAML_INDENT = 268,
-     YAML_IEND = 269
-   };
+
+
+/* First part of user prologue.  */
+#line 4 "gram.y"
+
+
+#define YYDEBUG 1
+#define YYERROR_VERBOSE 1
+#ifndef YYSTACK_USE_ALLOCA
+#define YYSTACK_USE_ALLOCA 0
 #endif
-#define YAML_ANCHOR 258
-#define YAML_ALIAS 259
-#define YAML_TRANSFER 260
-#define YAML_TAGURI 261
-#define YAML_ITRANSFER 262
-#define YAML_WORD 263
-#define YAML_PLAIN 264
-#define YAML_BLOCK 265
-#define YAML_DOCSEP 266
-#define YAML_IOPEN 267
-#define YAML_INDENT 268
-#define YAML_IEND 269
-
-
-
-
-/* Copy the first part of user declarations.  */
-#line 14 "gram.y"
-
 
 #include "syck.h"
 
 void apply_seq_in_map( SyckParser *parser, SyckNode *n );
 
-#define YYPARSE_PARAM   parser
-#define YYLEX_PARAM     parser
+#define YYPARSE_PARAM parser
+#define YYLEX_PARAM   parser
+
+#define yyparse           syckparse
+#define yylex(yylval)     sycklex(yylval, YYLEX_PARAM)
+#define yyerror(_, error) syckerror(error)
 
 #define NULL_NODE(parser, node) \
         SyckNode *node = syck_new_str( "", scalar_plain ); \
@@ -114,166 +98,438 @@ void apply_seq_in_map( SyckParser *parser, SyckNode *n );
             node->type_id = syck_strndup( "null", 4 ); \
         }
 
+#line 102 "gram.c"
 
-/* Enabling traces.  */
-#ifndef YYDEBUG
-# define YYDEBUG 1
+# ifndef YY_CAST
+#  ifdef __cplusplus
+#   define YY_CAST(Type, Val) static_cast<Type> (Val)
+#   define YY_REINTERPRET_CAST(Type, Val) reinterpret_cast<Type> (Val)
+#  else
+#   define YY_CAST(Type, Val) ((Type) (Val))
+#   define YY_REINTERPRET_CAST(Type, Val) ((Type) (Val))
+#  endif
+# endif
+# ifndef YY_NULLPTR
+#  if defined __cplusplus
+#   if 201103L <= __cplusplus
+#    define YY_NULLPTR nullptr
+#   else
+#    define YY_NULLPTR 0
+#   endif
+#  else
+#   define YY_NULLPTR ((void*)0)
+#  endif
+# endif
+
+#include "gram.h"
+/* Symbol kind.  */
+enum yysymbol_kind_t
+{
+  YYSYMBOL_YYEMPTY = -2,
+  YYSYMBOL_YYEOF = 0,                      /* "end of file"  */
+  YYSYMBOL_YYerror = 1,                    /* error  */
+  YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
+  YYSYMBOL_YAML_ANCHOR = 3,                /* YAML_ANCHOR  */
+  YYSYMBOL_YAML_ALIAS = 4,                 /* YAML_ALIAS  */
+  YYSYMBOL_YAML_TRANSFER = 5,              /* YAML_TRANSFER  */
+  YYSYMBOL_YAML_TAGURI = 6,                /* YAML_TAGURI  */
+  YYSYMBOL_YAML_ITRANSFER = 7,             /* YAML_ITRANSFER  */
+  YYSYMBOL_YAML_WORD = 8,                  /* YAML_WORD  */
+  YYSYMBOL_YAML_PLAIN = 9,                 /* YAML_PLAIN  */
+  YYSYMBOL_YAML_BLOCK = 10,                /* YAML_BLOCK  */
+  YYSYMBOL_YAML_DOCSEP = 11,               /* YAML_DOCSEP  */
+  YYSYMBOL_YAML_IOPEN = 12,                /* YAML_IOPEN  */
+  YYSYMBOL_YAML_INDENT = 13,               /* YAML_INDENT  */
+  YYSYMBOL_YAML_IEND = 14,                 /* YAML_IEND  */
+  YYSYMBOL_15_ = 15,                       /* '-'  */
+  YYSYMBOL_16_ = 16,                       /* ':'  */
+  YYSYMBOL_17_ = 17,                       /* '['  */
+  YYSYMBOL_18_ = 18,                       /* ']'  */
+  YYSYMBOL_19_ = 19,                       /* '{'  */
+  YYSYMBOL_20_ = 20,                       /* '}'  */
+  YYSYMBOL_21_ = 21,                       /* ','  */
+  YYSYMBOL_22_ = 22,                       /* '?'  */
+  YYSYMBOL_YYACCEPT = 23,                  /* $accept  */
+  YYSYMBOL_doc = 24,                       /* doc  */
+  YYSYMBOL_atom = 25,                      /* atom  */
+  YYSYMBOL_ind_rep = 26,                   /* ind_rep  */
+  YYSYMBOL_atom_or_empty = 27,             /* atom_or_empty  */
+  YYSYMBOL_empty = 28,                     /* empty  */
+  YYSYMBOL_indent_open = 29,               /* indent_open  */
+  YYSYMBOL_indent_end = 30,                /* indent_end  */
+  YYSYMBOL_indent_sep = 31,                /* indent_sep  */
+  YYSYMBOL_indent_flex_end = 32,           /* indent_flex_end  */
+  YYSYMBOL_word_rep = 33,                  /* word_rep  */
+  YYSYMBOL_struct_rep = 34,                /* struct_rep  */
+  YYSYMBOL_implicit_seq = 35,              /* implicit_seq  */
+  YYSYMBOL_basic_seq = 36,                 /* basic_seq  */
+  YYSYMBOL_top_imp_seq = 37,               /* top_imp_seq  */
+  YYSYMBOL_in_implicit_seq = 38,           /* in_implicit_seq  */
+  YYSYMBOL_inline_seq = 39,                /* inline_seq  */
+  YYSYMBOL_in_inline_seq = 40,             /* in_inline_seq  */
+  YYSYMBOL_inline_seq_atom = 41,           /* inline_seq_atom  */
+  YYSYMBOL_implicit_map = 42,              /* implicit_map  */
+  YYSYMBOL_top_imp_map = 43,               /* top_imp_map  */
+  YYSYMBOL_complex_key = 44,               /* complex_key  */
+  YYSYMBOL_complex_value = 45,             /* complex_value  */
+  YYSYMBOL_complex_mapping = 46,           /* complex_mapping  */
+  YYSYMBOL_in_implicit_map = 47,           /* in_implicit_map  */
+  YYSYMBOL_basic_mapping = 48,             /* basic_mapping  */
+  YYSYMBOL_inline_map = 49,                /* inline_map  */
+  YYSYMBOL_in_inline_map = 50,             /* in_inline_map  */
+  YYSYMBOL_inline_map_atom = 51            /* inline_map_atom  */
+};
+typedef enum yysymbol_kind_t yysymbol_kind_t;
+
+
+
+
+#ifdef short
+# undef short
 #endif
 
-/* Enabling verbose error messages.  */
-#ifdef YYERROR_VERBOSE
-# undef YYERROR_VERBOSE
-# define YYERROR_VERBOSE 1
+/* On compilers that do not define __PTRDIFF_MAX__ etc., make sure
+   <limits.h> and (if available) <stdint.h> are included
+   so that the code can choose integer types of a good width.  */
+
+#ifndef __PTRDIFF_MAX__
+# include <limits.h> /* INFRINGES ON USER NAME SPACE */
+# if defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#  include <stdint.h> /* INFRINGES ON USER NAME SPACE */
+#  define YY_STDINT_H
+# endif
+#endif
+
+/* Narrow types that promote to a signed type and that can represent a
+   signed or unsigned integer of at least N bits.  In tables they can
+   save space and decrease cache pressure.  Promoting to a signed type
+   helps avoid bugs in integer arithmetic.  */
+
+#ifdef __INT_LEAST8_MAX__
+typedef __INT_LEAST8_TYPE__ yytype_int8;
+#elif defined YY_STDINT_H
+typedef int_least8_t yytype_int8;
 #else
-# define YYERROR_VERBOSE 0
+typedef signed char yytype_int8;
 #endif
 
-#if ! defined (YYSTYPE) && ! defined (YYSTYPE_IS_DECLARED)
-#line 35 "gram.y"
-typedef union YYSTYPE {
-    SYMID nodeId;
-    SyckNode *nodeData;
-    char *name;
-} YYSTYPE;
-/* Line 191 of yacc.c.  */
-#line 140 "gram.c"
-# define yystype YYSTYPE /* obsolescent; will be withdrawn */
-# define YYSTYPE_IS_DECLARED 1
-# define YYSTYPE_IS_TRIVIAL 1
+#ifdef __INT_LEAST16_MAX__
+typedef __INT_LEAST16_TYPE__ yytype_int16;
+#elif defined YY_STDINT_H
+typedef int_least16_t yytype_int16;
+#else
+typedef short yytype_int16;
+#endif
+
+/* Work around bug in HP-UX 11.23, which defines these macros
+   incorrectly for preprocessor constants.  This workaround can likely
+   be removed in 2023, as HPE has promised support for HP-UX 11.23
+   (aka HP-UX 11i v2) only through the end of 2022; see Table 2 of
+   <https://h20195.www2.hpe.com/V2/getpdf.aspx/4AA4-7673ENW.pdf>.  */
+#ifdef __hpux
+# undef UINT_LEAST8_MAX
+# undef UINT_LEAST16_MAX
+# define UINT_LEAST8_MAX 255
+# define UINT_LEAST16_MAX 65535
+#endif
+
+#if defined __UINT_LEAST8_MAX__ && __UINT_LEAST8_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST8_TYPE__ yytype_uint8;
+#elif (!defined __UINT_LEAST8_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST8_MAX <= INT_MAX)
+typedef uint_least8_t yytype_uint8;
+#elif !defined __UINT_LEAST8_MAX__ && UCHAR_MAX <= INT_MAX
+typedef unsigned char yytype_uint8;
+#else
+typedef short yytype_uint8;
+#endif
+
+#if defined __UINT_LEAST16_MAX__ && __UINT_LEAST16_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST16_TYPE__ yytype_uint16;
+#elif (!defined __UINT_LEAST16_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST16_MAX <= INT_MAX)
+typedef uint_least16_t yytype_uint16;
+#elif !defined __UINT_LEAST16_MAX__ && USHRT_MAX <= INT_MAX
+typedef unsigned short yytype_uint16;
+#else
+typedef int yytype_uint16;
+#endif
+
+#ifndef YYPTRDIFF_T
+# if defined __PTRDIFF_TYPE__ && defined __PTRDIFF_MAX__
+#  define YYPTRDIFF_T __PTRDIFF_TYPE__
+#  define YYPTRDIFF_MAXIMUM __PTRDIFF_MAX__
+# elif defined PTRDIFF_MAX
+#  ifndef ptrdiff_t
+#   include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  endif
+#  define YYPTRDIFF_T ptrdiff_t
+#  define YYPTRDIFF_MAXIMUM PTRDIFF_MAX
+# else
+#  define YYPTRDIFF_T long
+#  define YYPTRDIFF_MAXIMUM LONG_MAX
+# endif
+#endif
+
+#ifndef YYSIZE_T
+# ifdef __SIZE_TYPE__
+#  define YYSIZE_T __SIZE_TYPE__
+# elif defined size_t
+#  define YYSIZE_T size_t
+# elif defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  define YYSIZE_T size_t
+# else
+#  define YYSIZE_T unsigned
+# endif
+#endif
+
+#define YYSIZE_MAXIMUM                                  \
+  YY_CAST (YYPTRDIFF_T,                                 \
+           (YYPTRDIFF_MAXIMUM < YY_CAST (YYSIZE_T, -1)  \
+            ? YYPTRDIFF_MAXIMUM                         \
+            : YY_CAST (YYSIZE_T, -1)))
+
+#define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
+
+
+/* Stored state numbers (used for stacks). */
+typedef yytype_int8 yy_state_t;
+
+/* State numbers in computations.  */
+typedef int yy_state_fast_t;
+
+#ifndef YY_
+# if defined YYENABLE_NLS && YYENABLE_NLS
+#  if ENABLE_NLS
+#   include <libintl.h> /* INFRINGES ON USER NAME SPACE */
+#   define YY_(Msgid) dgettext ("bison-runtime", Msgid)
+#  endif
+# endif
+# ifndef YY_
+#  define YY_(Msgid) Msgid
+# endif
 #endif
 
 
-
-/* Copy the second part of user declarations.  */
-
-
-/* Line 214 of yacc.c.  */
-#line 152 "gram.c"
-
-#if ! defined (yyoverflow) || YYERROR_VERBOSE
-
-# ifndef YYFREE
-#  define YYFREE free
+#ifndef YY_ATTRIBUTE_PURE
+# if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_PURE __attribute__ ((__pure__))
+# else
+#  define YY_ATTRIBUTE_PURE
 # endif
-# ifndef YYMALLOC
-#  define YYMALLOC malloc
+#endif
+
+#ifndef YY_ATTRIBUTE_UNUSED
+# if defined __GNUC__ && 2 < __GNUC__ + (7 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_UNUSED __attribute__ ((__unused__))
+# else
+#  define YY_ATTRIBUTE_UNUSED
 # endif
+#endif
+
+/* Suppress unused-variable warnings by "using" E.  */
+#if ! defined lint || defined __GNUC__
+# define YY_USE(E) ((void) (E))
+#else
+# define YY_USE(E) /* empty */
+#endif
+
+/* Suppress an incorrect diagnostic about yylval being uninitialized.  */
+#if defined __GNUC__ && ! defined __ICC && 406 <= __GNUC__ * 100 + __GNUC_MINOR__
+# if __GNUC__ * 100 + __GNUC_MINOR__ < 407
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")
+# else
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
+    _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+# endif
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
+    _Pragma ("GCC diagnostic pop")
+#else
+# define YY_INITIAL_VALUE(Value) Value
+#endif
+#ifndef YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END
+#endif
+#ifndef YY_INITIAL_VALUE
+# define YY_INITIAL_VALUE(Value) /* Nothing. */
+#endif
+
+#if defined __cplusplus && defined __GNUC__ && ! defined __ICC && 6 <= __GNUC__
+# define YY_IGNORE_USELESS_CAST_BEGIN                          \
+    _Pragma ("GCC diagnostic push")                            \
+    _Pragma ("GCC diagnostic ignored \"-Wuseless-cast\"")
+# define YY_IGNORE_USELESS_CAST_END            \
+    _Pragma ("GCC diagnostic pop")
+#endif
+#ifndef YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_END
+#endif
+
+
+#define YY_ASSERT(E) ((void) (0 && (E)))
+
+#if !defined yyoverflow
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */
 
 # ifdef YYSTACK_USE_ALLOCA
 #  if YYSTACK_USE_ALLOCA
-#   define YYSTACK_ALLOC alloca
-#  endif
-# else
-#  if defined (alloca) || defined (_ALLOCA_H)
-#   define YYSTACK_ALLOC alloca
-#  else
 #   ifdef __GNUC__
 #    define YYSTACK_ALLOC __builtin_alloca
+#   elif defined __BUILTIN_VA_ARG_INCR
+#    include <alloca.h> /* INFRINGES ON USER NAME SPACE */
+#   elif defined _AIX
+#    define YYSTACK_ALLOC __alloca
+#   elif defined _MSC_VER
+#    include <malloc.h> /* INFRINGES ON USER NAME SPACE */
+#    define alloca _alloca
+#   else
+#    define YYSTACK_ALLOC alloca
+#    if ! defined _ALLOCA_H && ! defined EXIT_SUCCESS
+#     include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
+      /* Use EXIT_SUCCESS as a witness for stdlib.h.  */
+#     ifndef EXIT_SUCCESS
+#      define EXIT_SUCCESS 0
+#     endif
+#    endif
 #   endif
 #  endif
 # endif
 
 # ifdef YYSTACK_ALLOC
-   /* Pacify GCC's `empty if-body' warning. */
+   /* Pacify GCC's 'empty if-body' warning.  */
 #  define YYSTACK_FREE(Ptr) do { /* empty */; } while (0)
-# else
-#  if defined (__STDC__) || defined (__cplusplus)
-#   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
-#   define YYSIZE_T size_t
+#  ifndef YYSTACK_ALLOC_MAXIMUM
+    /* The OS might guarantee only one guard page at the bottom of the stack,
+       and a page size can be as small as 4096 bytes.  So we cannot safely
+       invoke alloca (N) if N exceeds 4096.  Use a slightly smaller number
+       to allow for a few compiler-allocated temporary stack slots.  */
+#   define YYSTACK_ALLOC_MAXIMUM 4032 /* reasonable circa 2006 */
 #  endif
+# else
 #  define YYSTACK_ALLOC YYMALLOC
 #  define YYSTACK_FREE YYFREE
+#  ifndef YYSTACK_ALLOC_MAXIMUM
+#   define YYSTACK_ALLOC_MAXIMUM YYSIZE_MAXIMUM
+#  endif
+#  if (defined __cplusplus && ! defined EXIT_SUCCESS \
+       && ! ((defined YYMALLOC || defined malloc) \
+             && (defined YYFREE || defined free)))
+#   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
+#   ifndef EXIT_SUCCESS
+#    define EXIT_SUCCESS 0
+#   endif
+#  endif
+#  ifndef YYMALLOC
+#   define YYMALLOC malloc
+#   if ! defined malloc && ! defined EXIT_SUCCESS
+void *malloc (YYSIZE_T); /* INFRINGES ON USER NAME SPACE */
+#   endif
+#  endif
+#  ifndef YYFREE
+#   define YYFREE free
+#   if ! defined free && ! defined EXIT_SUCCESS
+void free (void *); /* INFRINGES ON USER NAME SPACE */
+#   endif
+#  endif
 # endif
-#endif /* ! defined (yyoverflow) || YYERROR_VERBOSE */
+#endif /* !defined yyoverflow */
 
-
-#if (! defined (yyoverflow) \
-     && (! defined (__cplusplus) \
-	 || (defined (YYSTYPE_IS_TRIVIAL) && YYSTYPE_IS_TRIVIAL)))
+#if (! defined yyoverflow \
+     && (! defined __cplusplus \
+         || (defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
 
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
 {
-  short int yyss;
-  YYSTYPE yyvs;
-  };
+  yy_state_t yyss_alloc;
+  YYSTYPE yyvs_alloc;
+};
 
 /* The size of the maximum gap between one aligned stack and the next.  */
-# define YYSTACK_GAP_MAXIMUM (sizeof (union yyalloc) - 1)
+# define YYSTACK_GAP_MAXIMUM (YYSIZEOF (union yyalloc) - 1)
 
 /* The size of an array large to enough to hold all stacks, each with
    N elements.  */
 # define YYSTACK_BYTES(N) \
-     ((N) * (sizeof (short int) + sizeof (YYSTYPE))			\
+     ((N) * (YYSIZEOF (yy_state_t) + YYSIZEOF (YYSTYPE)) \
       + YYSTACK_GAP_MAXIMUM)
 
-/* Copy COUNT objects from FROM to TO.  The source and destination do
-   not overlap.  */
-# ifndef YYCOPY
-#  if defined (__GNUC__) && 1 < __GNUC__
-#   define YYCOPY(To, From, Count) \
-      __builtin_memcpy (To, From, (Count) * sizeof (*(From)))
-#  else
-#   define YYCOPY(To, From, Count)		\
-      do					\
-	{					\
-	  register YYSIZE_T yyi;		\
-	  for (yyi = 0; yyi < (Count); yyi++)	\
-	    (To)[yyi] = (From)[yyi];		\
-	}					\
-      while (0)
-#  endif
-# endif
+# define YYCOPY_NEEDED 1
 
 /* Relocate STACK from its old location to the new one.  The
    local variables YYSIZE and YYSTACKSIZE give the old and new number of
    elements in the stack, and YYPTR gives the new location of the
    stack.  Advance YYPTR to a properly aligned location for the next
    stack.  */
-# define YYSTACK_RELOCATE(Stack)					\
-    do									\
-      {									\
-	YYSIZE_T yynewbytes;						\
-	YYCOPY (&yyptr->Stack, Stack, yysize);				\
-	Stack = &yyptr->Stack;						\
-	yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
-	yyptr += yynewbytes / sizeof (*yyptr);				\
-      }									\
+# define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
+    do                                                                  \
+      {                                                                 \
+        YYPTRDIFF_T yynewbytes;                                         \
+        YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
+        Stack = &yyptr->Stack_alloc;                                    \
+        yynewbytes = yystacksize * YYSIZEOF (*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / YYSIZEOF (*yyptr);                        \
+      }                                                                 \
     while (0)
 
 #endif
 
-#if defined (__STDC__) || defined (__cplusplus)
-   typedef signed char yysigned_char;
-#else
-   typedef short int yysigned_char;
-#endif
+#if defined YYCOPY_NEEDED && YYCOPY_NEEDED
+/* Copy COUNT objects from SRC to DST.  The source and destination do
+   not overlap.  */
+# ifndef YYCOPY
+#  if defined __GNUC__ && 1 < __GNUC__
+#   define YYCOPY(Dst, Src, Count) \
+      __builtin_memcpy (Dst, Src, YY_CAST (YYSIZE_T, (Count)) * sizeof (*(Src)))
+#  else
+#   define YYCOPY(Dst, Src, Count)              \
+      do                                        \
+        {                                       \
+          YYPTRDIFF_T yyi;                      \
+          for (yyi = 0; yyi < (Count); yyi++)   \
+            (Dst)[yyi] = (Src)[yyi];            \
+        }                                       \
+      while (0)
+#  endif
+# endif
+#endif /* !YYCOPY_NEEDED */
 
-/* YYFINAL -- State number of the termination state. */
+/* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  52
 /* YYLAST -- Last index in YYTABLE.  */
 #define YYLAST   396
 
-/* YYNTOKENS -- Number of terminals. */
+/* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS  23
-/* YYNNTS -- Number of nonterminals. */
+/* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  29
-/* YYNRULES -- Number of rules. */
+/* YYNRULES -- Number of rules.  */
 #define YYNRULES  79
-/* YYNRULES -- Number of states. */
+/* YYNSTATES -- Number of states.  */
 #define YYNSTATES  128
 
-/* YYTRANSLATE(YYLEX) -- Bison symbol number corresponding to YYLEX.  */
-#define YYUNDEFTOK  2
+/* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   269
 
-#define YYTRANSLATE(YYX) 						\
-  ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
 
-/* YYTRANSLATE[YYLEX] -- Bison symbol number corresponding to YYLEX.  */
-static const unsigned char yytranslate[] =
+/* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex, with out-of-bounds checking.  */
+#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_kind_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
+
+/* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex.  */
+static const yytype_int8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -305,150 +561,65 @@ static const unsigned char yytranslate[] =
 };
 
 #if YYDEBUG
-/* YYPRHS[YYN] -- Index of the first RHS symbol of rule number YYN in
-   YYRHS.  */
-static const unsigned char yyprhs[] =
+/* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
+static const yytype_int16 yyrline[] =
 {
-       0,     0,     3,     5,     8,     9,    11,    13,    15,    18,
-      21,    24,    28,    30,    32,    36,    37,    40,    43,    46,
-      49,    51,    54,    56,    58,    60,    63,    66,    69,    72,
-      75,    77,    79,    81,    85,    87,    89,    91,    93,    95,
-      99,   103,   106,   110,   113,   117,   120,   124,   127,   129,
-     133,   136,   140,   143,   145,   149,   151,   153,   157,   161,
-     165,   168,   172,   175,   179,   182,   184,   188,   190,   194,
-     196,   200,   204,   207,   211,   215,   218,   220,   224,   226
-};
-
-/* YYRHS -- A `-1'-separated list of the rules' RHS. */
-static const yysigned_char yyrhs[] =
-{
-      24,     0,    -1,    25,    -1,    11,    27,    -1,    -1,    33,
-      -1,    26,    -1,    34,    -1,     5,    26,    -1,     6,    26,
-      -1,     3,    26,    -1,    29,    26,    32,    -1,    25,    -1,
-      28,    -1,    29,    28,    30,    -1,    -1,     7,    28,    -1,
-       5,    28,    -1,     6,    28,    -1,     3,    28,    -1,    12,
-      -1,    29,    13,    -1,    14,    -1,    13,    -1,    14,    -1,
-      31,    32,    -1,     5,    33,    -1,     6,    33,    -1,     7,
-      33,    -1,     3,    33,    -1,     4,    -1,     8,    -1,     9,
-      -1,    29,    33,    32,    -1,    10,    -1,    35,    -1,    39,
-      -1,    42,    -1,    49,    -1,    29,    37,    30,    -1,    29,
-      38,    30,    -1,    15,    27,    -1,     5,    31,    38,    -1,
-       5,    37,    -1,     6,    31,    38,    -1,     6,    37,    -1,
-       3,    31,    38,    -1,     3,    37,    -1,    36,    -1,    38,
-      31,    36,    -1,    38,    31,    -1,    17,    40,    18,    -1,
-      17,    18,    -1,    41,    -1,    40,    21,    41,    -1,    25,
-      -1,    48,    -1,    29,    43,    30,    -1,    29,    47,    30,
-      -1,     5,    31,    47,    -1,     5,    43,    -1,     6,    31,
-      47,    -1,     6,    43,    -1,     3,    31,    47,    -1,     3,
-      43,    -1,    33,    -1,    22,    25,    31,    -1,    27,    -1,
-      44,    16,    45,    -1,    46,    -1,    47,    31,    36,    -1,
-      47,    31,    46,    -1,    47,    31,    -1,    25,    16,    27,
-      -1,    19,    50,    20,    -1,    19,    20,    -1,    51,    -1,
-      50,    21,    51,    -1,    25,    -1,    48,    -1
-};
-
-/* YYRLINE[YYN] -- source line where rule number YYN was defined.  */
-static const unsigned short int yyrline[] =
-{
-       0,    56,    56,    60,    65,    70,    71,    74,    75,    80,
-      85,    94,   100,   101,   104,   109,   113,   121,   126,   131,
-     145,   146,   149,   152,   155,   156,   164,   169,   174,   182,
-     186,   194,   207,   208,   218,   219,   220,   221,   222,   228,
-     232,   238,   244,   249,   254,   259,   264,   268,   274,   278,
-     283,   292,   296,   302,   306,   313,   314,   320,   325,   332,
-     337,   342,   347,   352,   356,   362,   363,   369,   379,   396,
-     397,   409,   417,   426,   434,   438,   444,   445,   454,   461
+       0,    57,    57,    61,    66,    71,    72,    75,    76,    81,
+      86,    95,   101,   102,   105,   110,   114,   122,   127,   132,
+     146,   147,   150,   153,   156,   157,   165,   170,   175,   183,
+     187,   195,   208,   209,   219,   220,   221,   222,   223,   229,
+     233,   239,   245,   250,   255,   260,   265,   269,   275,   279,
+     284,   293,   297,   303,   307,   314,   315,   321,   326,   333,
+     338,   343,   348,   353,   357,   363,   364,   370,   380,   397,
+     398,   410,   418,   427,   435,   439,   445,   446,   455,   462
 };
 #endif
 
-#if YYDEBUG || YYERROR_VERBOSE
-/* YYTNME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
-   First, the terminals, then, starting at YYNTOKENS, nonterminals. */
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_kind_t, yystos[State])
+
+#if YYDEBUG || 0
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+
+/* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
+   First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "$end", "error", "$undefined", "YAML_ANCHOR", "YAML_ALIAS",
-  "YAML_TRANSFER", "YAML_TAGURI", "YAML_ITRANSFER", "YAML_WORD",
-  "YAML_PLAIN", "YAML_BLOCK", "YAML_DOCSEP", "YAML_IOPEN", "YAML_INDENT",
-  "YAML_IEND", "'-'", "':'", "'['", "']'", "'{'", "'}'", "','", "'?'",
-  "$accept", "doc", "atom", "ind_rep", "atom_or_empty", "empty",
-  "indent_open", "indent_end", "indent_sep", "indent_flex_end", "word_rep",
-  "struct_rep", "implicit_seq", "basic_seq", "top_imp_seq",
+  "\"end of file\"", "error", "\"invalid token\"", "YAML_ANCHOR",
+  "YAML_ALIAS", "YAML_TRANSFER", "YAML_TAGURI", "YAML_ITRANSFER",
+  "YAML_WORD", "YAML_PLAIN", "YAML_BLOCK", "YAML_DOCSEP", "YAML_IOPEN",
+  "YAML_INDENT", "YAML_IEND", "'-'", "':'", "'['", "']'", "'{'", "'}'",
+  "','", "'?'", "$accept", "doc", "atom", "ind_rep", "atom_or_empty",
+  "empty", "indent_open", "indent_end", "indent_sep", "indent_flex_end",
+  "word_rep", "struct_rep", "implicit_seq", "basic_seq", "top_imp_seq",
   "in_implicit_seq", "inline_seq", "in_inline_seq", "inline_seq_atom",
   "implicit_map", "top_imp_map", "complex_key", "complex_value",
   "complex_mapping", "in_implicit_map", "basic_mapping", "inline_map",
-  "in_inline_map", "inline_map_atom", 0
+  "in_inline_map", "inline_map_atom", YY_NULLPTR
 };
+
+static const char *
+yysymbol_name (yysymbol_kind_t yysymbol)
+{
+  return yytname[yysymbol];
+}
 #endif
 
-# ifdef YYPRINT
-/* YYTOKNUM[YYLEX-NUM] -- Internal token number corresponding to
-   token YYLEX-NUM.  */
-static const unsigned short int yytoknum[] =
-{
-       0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
-     265,   266,   267,   268,   269,    45,    58,    91,    93,   123,
-     125,    44,    63
-};
-# endif
+#define YYPACT_NINF (-97)
 
-/* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
-static const unsigned char yyr1[] =
-{
-       0,    23,    24,    24,    24,    25,    25,    26,    26,    26,
-      26,    26,    27,    27,    28,    28,    28,    28,    28,    28,
-      29,    29,    30,    31,    32,    32,    33,    33,    33,    33,
-      33,    33,    33,    33,    34,    34,    34,    34,    34,    35,
-      35,    36,    37,    37,    37,    37,    37,    37,    38,    38,
-      38,    39,    39,    40,    40,    41,    41,    42,    42,    43,
-      43,    43,    43,    43,    43,    44,    44,    45,    46,    47,
-      47,    47,    47,    48,    49,    49,    50,    50,    51,    51
-};
+#define yypact_value_is_default(Yyn) \
+  ((Yyn) == YYPACT_NINF)
 
-/* YYR2[YYN] -- Number of symbols composing right hand side of rule YYN.  */
-static const unsigned char yyr2[] =
-{
-       0,     2,     1,     2,     0,     1,     1,     1,     2,     2,
-       2,     3,     1,     1,     3,     0,     2,     2,     2,     2,
-       1,     2,     1,     1,     1,     2,     2,     2,     2,     2,
-       1,     1,     1,     3,     1,     1,     1,     1,     1,     3,
-       3,     2,     3,     2,     3,     2,     3,     2,     1,     3,
-       2,     3,     2,     1,     3,     1,     1,     3,     3,     3,
-       2,     3,     2,     3,     2,     1,     3,     1,     3,     1,
-       3,     3,     2,     3,     3,     2,     1,     3,     1,     1
-};
+#define YYTABLE_NINF (-1)
 
-/* YYDEFACT[STATE-NAME] -- Default rule to reduce with in state
-   STATE-NUM when YYTABLE doesn't specify something else to do.  Zero
-   means the default is an error.  */
-static const unsigned char yydefact[] =
-{
-       4,     0,    30,     0,     0,     0,    31,    32,    34,    15,
-      20,     0,     0,     0,     2,     6,     0,     5,     7,    35,
-      36,    37,    38,    10,    29,     8,    26,     9,    27,     0,
-       0,     0,     0,    28,    15,    15,    15,    15,    12,     3,
-      13,    15,    52,    55,     0,    53,    56,    75,    78,    79,
-       0,    76,     1,     0,     0,     0,    21,    15,     0,     0,
-      65,    48,     0,     0,     0,     0,    69,     0,     0,    19,
-      17,    18,    15,    15,    15,    16,    15,    15,    15,    15,
-       0,    15,    51,     0,    74,     0,    23,     0,    47,    64,
-       0,    43,    60,     0,    45,    62,    41,     0,    24,     0,
-      11,    33,    22,    39,    40,    50,    57,    15,    58,    72,
-      14,    73,    54,    77,    65,    46,    63,    42,    59,    44,
-      61,    66,    25,    49,    67,    68,    70,    71
-};
-
-/* YYDEFGOTO[NTERM-NUM]. */
-static const yysigned_char yydefgoto[] =
-{
-      -1,    13,    38,    15,    39,    40,    16,   103,    99,   101,
-      17,    18,    19,    61,    62,    63,    20,    44,    45,    21,
-      64,    65,   125,    66,    67,    46,    22,    50,    51
-};
+#define yytable_value_is_error(Yyn) \
+  0
 
 /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
    STATE-NUM.  */
-#define YYPACT_NINF -97
-static const short int yypact[] =
+static const yytype_int16 yypact[] =
 {
      250,   318,   -97,   318,   318,   374,   -97,   -97,   -97,   335,
      -97,   267,   232,     7,   -97,   -97,   192,   -97,   -97,   -97,
@@ -465,20 +636,46 @@ static const short int yypact[] =
       24,   -97,   -97,   -97,   -97,   -97,   -97,   -97
 };
 
+/* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+   Performed when YYTABLE does not specify something else to do.  Zero
+   means the default is an error.  */
+static const yytype_int8 yydefact[] =
+{
+       4,     0,    30,     0,     0,     0,    31,    32,    34,    15,
+      20,     0,     0,     0,     2,     6,     0,     5,     7,    35,
+      36,    37,    38,    10,    29,     8,    26,     9,    27,     0,
+       0,     0,     0,    28,    15,    15,    15,    15,    12,     3,
+      13,    15,    52,    55,     0,    53,    56,    75,    78,    79,
+       0,    76,     1,     0,     0,     0,    21,    15,     0,     0,
+      65,    48,     0,     0,     0,     0,    69,     0,     0,    19,
+      17,    18,    15,    15,    15,    16,    15,    15,    15,    15,
+       0,    15,    51,     0,    74,     0,    23,     0,    47,    64,
+       0,    43,    60,     0,    45,    62,    41,     0,    24,     0,
+      11,    33,    22,    39,    40,    50,    57,    15,    58,    72,
+      14,    73,    54,    77,    65,    46,    63,    42,    59,    44,
+      61,    66,    25,    49,    67,    68,    70,    71
+};
+
 /* YYPGOTO[NTERM-NUM].  */
-static const yysigned_char yypgoto[] =
+static const yytype_int8 yypgoto[] =
 {
      -97,   -97,     8,    81,   -56,   109,    33,   -53,    74,   -54,
       -1,   -97,   -97,   -96,   -31,   -32,   -97,   -97,   -44,   -97,
       77,   -97,   -97,   -52,     9,    -6,   -97,   -97,   -29
 };
 
-/* YYTABLE[YYPACT[STATE-NUM]].  What to do in state STATE-NUM.  If
-   positive, shift that token.  If negative, reduce the rule which
-   number is the opposite.  If zero, do what YYDEFACT says.
-   If YYTABLE_NINF, syntax error.  */
-#define YYTABLE_NINF -1
-static const unsigned char yytable[] =
+/* YYDEFGOTO[NTERM-NUM].  */
+static const yytype_int8 yydefgoto[] =
+{
+       0,    13,    38,    15,    39,    40,    16,   103,    99,   101,
+      17,    18,    19,    61,    62,    63,    20,    44,    45,    21,
+      64,    65,   125,    66,    67,    46,    22,    50,    51
+};
+
+/* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+   positive, shift that token.  If negative, reduce the rule whose
+   number is the opposite.  If YYTABLE_NINF, syntax error.  */
+static const yytype_int8 yytable[] =
 {
       24,    96,    26,    28,    33,   100,    49,    52,    14,   123,
      104,   106,   102,   126,   108,    60,    84,    85,    82,    43,
@@ -522,7 +719,7 @@ static const unsigned char yytable[] =
       74,    37,     6,     7,     0,     0,    10
 };
 
-static const yysigned_char yycheck[] =
+static const yytype_int8 yycheck[] =
 {
        1,    57,     3,     4,     5,    59,    12,     0,     0,   105,
       63,    64,    14,   109,    67,    16,    20,    21,    18,    11,
@@ -566,9 +763,9 @@ static const yysigned_char yycheck[] =
        6,     7,     8,     9,    -1,    -1,    12
 };
 
-/* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-   symbol of state STATE-NUM.  */
-static const unsigned char yystos[] =
+/* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
+   state STATE-NUM.  */
+static const yytype_int8 yystos[] =
 {
        0,     3,     4,     5,     6,     7,     8,     9,    10,    11,
       12,    17,    19,    24,    25,    26,    29,    33,    34,    35,
@@ -585,78 +782,67 @@ static const unsigned char yystos[] =
       47,    31,    32,    36,    27,    45,    36,    46
 };
 
-#if ! defined (YYSIZE_T) && defined (__SIZE_TYPE__)
-# define YYSIZE_T __SIZE_TYPE__
-#endif
-#if ! defined (YYSIZE_T) && defined (size_t)
-# define YYSIZE_T size_t
-#endif
-#if ! defined (YYSIZE_T)
-# if defined (__STDC__) || defined (__cplusplus)
-#  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
-#  define YYSIZE_T size_t
-# endif
-#endif
-#if ! defined (YYSIZE_T)
-# define YYSIZE_T unsigned int
-#endif
+/* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr1[] =
+{
+       0,    23,    24,    24,    24,    25,    25,    26,    26,    26,
+      26,    26,    27,    27,    28,    28,    28,    28,    28,    28,
+      29,    29,    30,    31,    32,    32,    33,    33,    33,    33,
+      33,    33,    33,    33,    34,    34,    34,    34,    34,    35,
+      35,    36,    37,    37,    37,    37,    37,    37,    38,    38,
+      38,    39,    39,    40,    40,    41,    41,    42,    42,    43,
+      43,    43,    43,    43,    43,    44,    44,    45,    46,    47,
+      47,    47,    47,    48,    49,    49,    50,    50,    51,    51
+};
 
-#define yyerrok		(yyerrstatus = 0)
-#define yyclearin	(yychar = YYEMPTY)
-#define YYEMPTY		(-2)
-#define YYEOF		0
+/* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr2[] =
+{
+       0,     2,     1,     2,     0,     1,     1,     1,     2,     2,
+       2,     3,     1,     1,     3,     0,     2,     2,     2,     2,
+       1,     2,     1,     1,     1,     2,     2,     2,     2,     2,
+       1,     1,     1,     3,     1,     1,     1,     1,     1,     3,
+       3,     2,     3,     2,     3,     2,     3,     2,     1,     3,
+       2,     3,     2,     1,     3,     1,     1,     3,     3,     3,
+       2,     3,     2,     3,     2,     1,     3,     1,     3,     1,
+       3,     3,     2,     3,     3,     2,     1,     3,     1,     1
+};
 
-#define YYACCEPT	goto yyacceptlab
-#define YYABORT		goto yyabortlab
-#define YYERROR		goto yyerrorlab
 
+enum { YYENOMEM = -2 };
 
-/* Like YYERROR except do call yyerror.  This remains here temporarily
-   to ease the transition to the new meaning of YYERROR, for GCC.
-   Once GCC version 2 has supplanted version 1, this can go.  */
+#define yyerrok         (yyerrstatus = 0)
+#define yyclearin       (yychar = YYEMPTY)
 
-#define YYFAIL		goto yyerrlab
+#define YYACCEPT        goto yyacceptlab
+#define YYABORT         goto yyabortlab
+#define YYERROR         goto yyerrorlab
+#define YYNOMEM         goto yyexhaustedlab
+
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
-#define YYBACKUP(Token, Value)					\
-do								\
-  if (yychar == YYEMPTY && yylen == 1)				\
-    {								\
-      yychar = (Token);						\
-      yylval = (Value);						\
-      yytoken = YYTRANSLATE (yychar);				\
-      YYPOPSTACK;						\
-      goto yybackup;						\
-    }								\
-  else								\
-    { 								\
-      yyerror ("syntax error: cannot back up");\
-      YYERROR;							\
-    }								\
-while (0)
+#define YYBACKUP(Token, Value)                                    \
+  do                                                              \
+    if (yychar == YYEMPTY)                                        \
+      {                                                           \
+        yychar = (Token);                                         \
+        yylval = (Value);                                         \
+        YYPOPSTACK (yylen);                                       \
+        yystate = *yyssp;                                         \
+        goto yybackup;                                            \
+      }                                                           \
+    else                                                          \
+      {                                                           \
+        yyerror (YYPARSE_PARAM, YY_("syntax error: cannot back up")); \
+        YYERROR;                                                  \
+      }                                                           \
+  while (0)
 
-#define YYTERROR	1
-#define YYERRCODE	256
+/* Backward compatibility with an undocumented macro.
+   Use YYerror or YYUNDEF. */
+#define YYERRCODE YYUNDEF
 
-/* YYLLOC_DEFAULT -- Compute the default location (before the actions
-   are run).  */
-
-#ifndef YYLLOC_DEFAULT
-# define YYLLOC_DEFAULT(Current, Rhs, N)		\
-   ((Current).first_line   = (Rhs)[1].first_line,	\
-    (Current).first_column = (Rhs)[1].first_column,	\
-    (Current).last_line    = (Rhs)[N].last_line,	\
-    (Current).last_column  = (Rhs)[N].last_column)
-#endif
-
-/* YYLEX -- calling `yylex' with the right arguments.  */
-
-#ifdef YYLEX_PARAM
-# define YYLEX yylex (&yylval, YYLEX_PARAM)
-#else
-# define YYLEX yylex (&yylval)
-#endif
 
 /* Enable debugging if requested.  */
 #if YYDEBUG
@@ -666,54 +852,82 @@ while (0)
 #  define YYFPRINTF fprintf
 # endif
 
-# define YYDPRINTF(Args)			\
-do {						\
-  if (yydebug)					\
-    YYFPRINTF Args;				\
+# define YYDPRINTF(Args)                        \
+do {                                            \
+  if (yydebug)                                  \
+    YYFPRINTF Args;                             \
 } while (0)
 
-# define YYDSYMPRINT(Args)			\
-do {						\
-  if (yydebug)					\
-    yysymprint Args;				\
+
+
+
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
+do {                                                                      \
+  if (yydebug)                                                            \
+    {                                                                     \
+      YYFPRINTF (stderr, "%s ", Title);                                   \
+      yy_symbol_print (stderr,                                            \
+                  Kind, Value, YYPARSE_PARAM); \
+      YYFPRINTF (stderr, "\n");                                           \
+    }                                                                     \
 } while (0)
 
-# define YYDSYMPRINTF(Title, Token, Value, Location)		\
-do {								\
-  if (yydebug)							\
-    {								\
-      YYFPRINTF (stderr, "%s ", Title);				\
-      yysymprint (stderr, 					\
-                  Token, Value);	\
-      YYFPRINTF (stderr, "\n");					\
-    }								\
-} while (0)
+
+/*-----------------------------------.
+| Print this symbol's value on YYO.  |
+`-----------------------------------*/
+
+static void
+yy_symbol_value_print (FILE *yyo,
+                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, void *YYPARSE_PARAM)
+{
+  FILE *yyoutput = yyo;
+  YY_USE (yyoutput);
+  YY_USE (YYPARSE_PARAM);
+  if (!yyvaluep)
+    return;
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  YY_USE (yykind);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
+}
+
+
+/*---------------------------.
+| Print this symbol on YYO.  |
+`---------------------------*/
+
+static void
+yy_symbol_print (FILE *yyo,
+                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, void *YYPARSE_PARAM)
+{
+  YYFPRINTF (yyo, "%s %s (",
+             yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name (yykind));
+
+  yy_symbol_value_print (yyo, yykind, yyvaluep, YYPARSE_PARAM);
+  YYFPRINTF (yyo, ")");
+}
 
 /*------------------------------------------------------------------.
 | yy_stack_print -- Print the state stack from its BOTTOM up to its |
 | TOP (included).                                                   |
 `------------------------------------------------------------------*/
 
-#if defined (__STDC__) || defined (__cplusplus)
 static void
-yy_stack_print (short int *bottom, short int *top)
-#else
-static void
-yy_stack_print (bottom, top)
-    short int *bottom;
-    short int *top;
-#endif
+yy_stack_print (yy_state_t *yybottom, yy_state_t *yytop)
 {
   YYFPRINTF (stderr, "Stack now");
-  for (/* Nothing. */; bottom <= top; ++bottom)
-    YYFPRINTF (stderr, " %d", *bottom);
+  for (; yybottom <= yytop; yybottom++)
+    {
+      int yybot = *yybottom;
+      YYFPRINTF (stderr, " %d", yybot);
+    }
   YYFPRINTF (stderr, "\n");
 }
 
-# define YY_STACK_PRINT(Bottom, Top)				\
-do {								\
-  if (yydebug)							\
-    yy_stack_print ((Bottom), (Top));				\
+# define YY_STACK_PRINT(Bottom, Top)                            \
+do {                                                            \
+  if (yydebug)                                                  \
+    yy_stack_print ((Bottom), (Top));                           \
 } while (0)
 
 
@@ -721,45 +935,45 @@ do {								\
 | Report that the YYRULE is going to be reduced.  |
 `------------------------------------------------*/
 
-#if defined (__STDC__) || defined (__cplusplus)
 static void
-yy_reduce_print (int yyrule)
-#else
-static void
-yy_reduce_print (yyrule)
-    int yyrule;
-#endif
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp,
+                 int yyrule, void *YYPARSE_PARAM)
 {
+  int yylno = yyrline[yyrule];
+  int yynrhs = yyr2[yyrule];
   int yyi;
-  unsigned int yylno = yyrline[yyrule];
-  YYFPRINTF (stderr, "Reducing stack by rule %d (line %u), ",
+  YYFPRINTF (stderr, "Reducing stack by rule %d (line %d):\n",
              yyrule - 1, yylno);
-  /* Print the symbols being reduced, and their result.  */
-  for (yyi = yyprhs[yyrule]; 0 <= yyrhs[yyi]; yyi++)
-    YYFPRINTF (stderr, "%s ", yytname [yyrhs[yyi]]);
-  YYFPRINTF (stderr, "-> %s\n", yytname [yyr1[yyrule]]);
+  /* The symbols being reduced.  */
+  for (yyi = 0; yyi < yynrhs; yyi++)
+    {
+      YYFPRINTF (stderr, "   $%d = ", yyi + 1);
+      yy_symbol_print (stderr,
+                       YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
+                       &yyvsp[(yyi + 1) - (yynrhs)], YYPARSE_PARAM);
+      YYFPRINTF (stderr, "\n");
+    }
 }
 
-# define YY_REDUCE_PRINT(Rule)		\
-do {					\
-  if (yydebug)				\
-    yy_reduce_print (Rule);		\
+# define YY_REDUCE_PRINT(Rule)          \
+do {                                    \
+  if (yydebug)                          \
+    yy_reduce_print (yyssp, yyvsp, Rule, YYPARSE_PARAM); \
 } while (0)
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
    multiple parsers can coexist.  */
 int yydebug;
 #else /* !YYDEBUG */
-# define YYDPRINTF(Args)
-# define YYDSYMPRINT(Args)
-# define YYDSYMPRINTF(Title, Token, Value, Location)
+# define YYDPRINTF(Args) ((void) 0)
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)
 # define YY_STACK_PRINT(Bottom, Top)
 # define YY_REDUCE_PRINT(Rule)
 #endif /* !YYDEBUG */
 
 
 /* YYINITDEPTH -- initial size of the parser's stacks.  */
-#ifndef	YYINITDEPTH
+#ifndef YYINITDEPTH
 # define YYINITDEPTH 200
 #endif
 
@@ -767,153 +981,36 @@ int yydebug;
    if the built-in stack extension method is used).
 
    Do not make this value too large; the results are undefined if
-   SIZE_MAX < YYSTACK_BYTES (YYMAXDEPTH)
+   YYSTACK_ALLOC_MAXIMUM < YYSTACK_BYTES (YYMAXDEPTH)
    evaluated with infinite-precision integer arithmetic.  */
-
-#if defined (YYMAXDEPTH) && YYMAXDEPTH == 0
-# undef YYMAXDEPTH
-#endif
 
 #ifndef YYMAXDEPTH
 # define YYMAXDEPTH 10000
 #endif
 
-
 
-#if YYERROR_VERBOSE
 
-# ifndef yystrlen
-#  if defined (__GLIBC__) && defined (_STRING_H)
-#   define yystrlen strlen
-#  else
-/* Return the length of YYSTR.  */
-static YYSIZE_T
-#   if defined (__STDC__) || defined (__cplusplus)
-yystrlen (const char *yystr)
-#   else
-yystrlen (yystr)
-     const char *yystr;
-#   endif
-{
-  register const char *yys = yystr;
 
-  while (*yys++ != '\0')
-    continue;
 
-  return yys - yystr - 1;
-}
-#  endif
-# endif
 
-# ifndef yystpcpy
-#  if defined (__GLIBC__) && defined (_STRING_H) && defined (_GNU_SOURCE)
-#   define yystpcpy stpcpy
-#  else
-/* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
-   YYDEST.  */
-static char *
-#   if defined (__STDC__) || defined (__cplusplus)
-yystpcpy (char *yydest, const char *yysrc)
-#   else
-yystpcpy (yydest, yysrc)
-     char *yydest;
-     const char *yysrc;
-#   endif
-{
-  register char *yyd = yydest;
-  register const char *yys = yysrc;
-
-  while ((*yyd++ = *yys++) != '\0')
-    continue;
-
-  return yyd - 1;
-}
-#  endif
-# endif
-
-#endif /* !YYERROR_VERBOSE */
-
-
-
-#if YYDEBUG
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
-
-#if defined (__STDC__) || defined (__cplusplus)
-static void
-yysymprint (FILE *yyoutput, int yytype, YYSTYPE *yyvaluep)
-#else
-static void
-yysymprint (yyoutput, yytype, yyvaluep)
-    FILE *yyoutput;
-    int yytype;
-    YYSTYPE *yyvaluep;
-#endif
-{
-  /* Pacify ``unused variable'' warnings.  */
-  (void) yyvaluep;
-
-  if (yytype < YYNTOKENS)
-    {
-      YYFPRINTF (yyoutput, "token %s (", yytname[yytype]);
-# ifdef YYPRINT
-      YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
-# endif
-    }
-  else
-    YYFPRINTF (yyoutput, "nterm %s (", yytname[yytype]);
-
-  switch (yytype)
-    {
-      default:
-        break;
-    }
-  YYFPRINTF (yyoutput, ")");
-}
-
-#endif /* ! YYDEBUG */
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
-#if defined (__STDC__) || defined (__cplusplus)
 static void
-yydestruct (int yytype, YYSTYPE *yyvaluep)
-#else
-static void
-yydestruct (yytype, yyvaluep)
-    int yytype;
-    YYSTYPE *yyvaluep;
-#endif
+yydestruct (const char *yymsg,
+            yysymbol_kind_t yykind, YYSTYPE *yyvaluep, void *YYPARSE_PARAM)
 {
-  /* Pacify ``unused variable'' warnings.  */
-  (void) yyvaluep;
+  YY_USE (yyvaluep);
+  YY_USE (YYPARSE_PARAM);
+  if (!yymsg)
+    yymsg = "Deleting";
+  YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
 
-  switch (yytype)
-    {
-
-      default:
-        break;
-    }
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  YY_USE (yykind);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
-
-
-/* Prevent warnings from -Wmissing-prototypes.  */
-
-#ifdef YYPARSE_PARAM
-# if defined (__STDC__) || defined (__cplusplus)
-int yyparse (void *YYPARSE_PARAM);
-# else
-int yyparse ();
-# endif
-#else /* ! YYPARSE_PARAM */
-#if defined (__STDC__) || defined (__cplusplus)
-int yyparse (void);
-#else
-int yyparse ();
-#endif
-#endif /* ! YYPARSE_PARAM */
 
 
 
@@ -924,206 +1021,197 @@ int yyparse ();
 | yyparse.  |
 `----------*/
 
-#ifdef YYPARSE_PARAM
-# if defined (__STDC__) || defined (__cplusplus)
-int yyparse (void *YYPARSE_PARAM)
-# else
-int yyparse (YYPARSE_PARAM)
-  void *YYPARSE_PARAM;
-# endif
-#else /* ! YYPARSE_PARAM */
-#if defined (__STDC__) || defined (__cplusplus)
 int
-yyparse (void)
-#else
-int
-yyparse ()
-
-#endif
-#endif
+yyparse (void *YYPARSE_PARAM)
 {
-  /* The lookahead symbol.  */
+/* Lookahead token kind.  */
 int yychar;
 
+
 /* The semantic value of the lookahead symbol.  */
-YYSTYPE yylval;
+/* Default value used for initialization, for pacifying older GCCs
+   or non-GCC compilers.  */
+YY_INITIAL_VALUE (static YYSTYPE yyval_default;)
+YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
 
-/* Number of syntax errors so far.  */
-int yynerrs;
+    /* Number of syntax errors so far.  */
+    int yynerrs = 0;
 
-  register int yystate;
-  register int yyn;
+    yy_state_fast_t yystate = 0;
+    /* Number of tokens to shift before error messages enabled.  */
+    int yyerrstatus = 0;
+
+    /* Refer to the stacks through separate pointers, to allow yyoverflow
+       to reallocate them elsewhere.  */
+
+    /* Their size.  */
+    YYPTRDIFF_T yystacksize = YYINITDEPTH;
+
+    /* The state stack: array, bottom, top.  */
+    yy_state_t yyssa[YYINITDEPTH];
+    yy_state_t *yyss = yyssa;
+    yy_state_t *yyssp = yyss;
+
+    /* The semantic value stack: array, bottom, top.  */
+    YYSTYPE yyvsa[YYINITDEPTH];
+    YYSTYPE *yyvs = yyvsa;
+    YYSTYPE *yyvsp = yyvs;
+
+  int yyn;
+  /* The return value of yyparse.  */
   int yyresult;
-  /* Number of tokens to shift before error messages enabled.  */
-  int yyerrstatus;
-  /* Lookahead token as an internal (translated) token number.  */
-  int yytoken = 0;
-
-  /* Three stacks and their tools:
-     `yyss': related to states,
-     `yyvs': related to semantic values,
-     `yyls': related to locations.
-
-     Refer to the stacks thru separate pointers, to allow yyoverflow
-     to reallocate them elsewhere.  */
-
-  /* The state stack.  */
-  short int yyssa[YYINITDEPTH];
-  short int *yyss = yyssa;
-  register short int *yyssp;
-
-  /* The semantic value stack.  */
-  YYSTYPE yyvsa[YYINITDEPTH];
-  YYSTYPE *yyvs = yyvsa;
-  register YYSTYPE *yyvsp;
-
-
-
-#define YYPOPSTACK   (yyvsp--, yyssp--)
-
-  YYSIZE_T yystacksize = YYINITDEPTH;
-
+  /* Lookahead symbol kind.  */
+  yysymbol_kind_t yytoken = YYSYMBOL_YYEMPTY;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;
 
 
-  /* When reducing, the number of symbols on the RHS of the reduced
-     rule.  */
-  int yylen;
+
+#define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N))
+
+  /* The number of symbols on the RHS of the reduced rule.
+     Keep to zero when no symbol should be popped.  */
+  int yylen = 0;
 
   YYDPRINTF ((stderr, "Starting parse\n"));
 
-  yystate = 0;
-  yyerrstatus = 0;
-  yynerrs = 0;
-  yychar = YYEMPTY;		/* Cause a token to be read.  */
-
-  /* Initialize stack pointers.
-     Waste one element of value and location stack
-     so that they stay on the same level as the state stack.
-     The wasted elements are never initialized.  */
-
-  yyssp = yyss;
-  yyvsp = yyvs;
-
+  yychar = YYEMPTY; /* Cause a token to be read.  */
 
   goto yysetstate;
 
+
 /*------------------------------------------------------------.
-| yynewstate -- Push a new state, which is found in yystate.  |
+| yynewstate -- push a new state, which is found in yystate.  |
 `------------------------------------------------------------*/
- yynewstate:
+yynewstate:
   /* In all cases, when you get here, the value and location stacks
-     have just been pushed. so pushing a state here evens the stacks.
-     */
+     have just been pushed.  So pushing a state here evens the stacks.  */
   yyssp++;
 
- yysetstate:
-  *yyssp = yystate;
+
+/*--------------------------------------------------------------------.
+| yysetstate -- set current state (the top of the stack) to yystate.  |
+`--------------------------------------------------------------------*/
+yysetstate:
+  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+  YY_ASSERT (0 <= yystate && yystate < YYNSTATES);
+  YY_IGNORE_USELESS_CAST_BEGIN
+  *yyssp = YY_CAST (yy_state_t, yystate);
+  YY_IGNORE_USELESS_CAST_END
+  YY_STACK_PRINT (yyss, yyssp);
 
   if (yyss + yystacksize - 1 <= yyssp)
+#if !defined yyoverflow && !defined YYSTACK_RELOCATE
+    YYNOMEM;
+#else
     {
       /* Get the current used size of the three stacks, in elements.  */
-      YYSIZE_T yysize = yyssp - yyss + 1;
+      YYPTRDIFF_T yysize = yyssp - yyss + 1;
 
-#ifdef yyoverflow
+# if defined yyoverflow
       {
-	/* Give user a chance to reallocate the stack. Use copies of
-	   these so that the &'s don't force the real ones into
-	   memory.  */
-	YYSTYPE *yyvs1 = yyvs;
-	short int *yyss1 = yyss;
+        /* Give user a chance to reallocate the stack.  Use copies of
+           these so that the &'s don't force the real ones into
+           memory.  */
+        yy_state_t *yyss1 = yyss;
+        YYSTYPE *yyvs1 = yyvs;
 
-
-	/* Each stack pointer address is followed by the size of the
-	   data in use in that stack, in bytes.  This used to be a
-	   conditional around just the two extra args, but that might
-	   be undefined if yyoverflow is a macro.  */
-	yyoverflow ("parser stack overflow",
-		    &yyss1, yysize * sizeof (*yyssp),
-		    &yyvs1, yysize * sizeof (*yyvsp),
-
-		    &yystacksize);
-
-	yyss = yyss1;
-	yyvs = yyvs1;
+        /* Each stack pointer address is followed by the size of the
+           data in use in that stack, in bytes.  This used to be a
+           conditional around just the two extra args, but that might
+           be undefined if yyoverflow is a macro.  */
+        yyoverflow (YY_("memory exhausted"),
+                    &yyss1, yysize * YYSIZEOF (*yyssp),
+                    &yyvs1, yysize * YYSIZEOF (*yyvsp),
+                    &yystacksize);
+        yyss = yyss1;
+        yyvs = yyvs1;
       }
-#else /* no yyoverflow */
-# ifndef YYSTACK_RELOCATE
-      goto yyoverflowlab;
-# else
+# else /* defined YYSTACK_RELOCATE */
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
-	goto yyoverflowlab;
+        YYNOMEM;
       yystacksize *= 2;
       if (YYMAXDEPTH < yystacksize)
-	yystacksize = YYMAXDEPTH;
+        yystacksize = YYMAXDEPTH;
 
       {
-	short int *yyss1 = yyss;
-	union yyalloc *yyptr =
-	  (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
-	if (! yyptr)
-	  goto yyoverflowlab;
-	YYSTACK_RELOCATE (yyss);
-	YYSTACK_RELOCATE (yyvs);
-
+        yy_state_t *yyss1 = yyss;
+        union yyalloc *yyptr =
+          YY_CAST (union yyalloc *,
+                   YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
+        if (! yyptr)
+          YYNOMEM;
+        YYSTACK_RELOCATE (yyss_alloc, yyss);
+        YYSTACK_RELOCATE (yyvs_alloc, yyvs);
 #  undef YYSTACK_RELOCATE
-	if (yyss1 != yyssa)
-	  YYSTACK_FREE (yyss1);
+        if (yyss1 != yyssa)
+          YYSTACK_FREE (yyss1);
       }
 # endif
-#endif /* no yyoverflow */
 
       yyssp = yyss + yysize - 1;
       yyvsp = yyvs + yysize - 1;
 
-
-      YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-		  (unsigned long int) yystacksize));
+      YY_IGNORE_USELESS_CAST_BEGIN
+      YYDPRINTF ((stderr, "Stack size increased to %ld\n",
+                  YY_CAST (long, yystacksize)));
+      YY_IGNORE_USELESS_CAST_END
 
       if (yyss + yystacksize - 1 <= yyssp)
-	YYABORT;
+        YYABORT;
     }
+#endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
 
-  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+
+  if (yystate == YYFINAL)
+    YYACCEPT;
 
   goto yybackup;
+
 
 /*-----------.
 | yybackup.  |
 `-----------*/
 yybackup:
-
-/* Do appropriate processing given the current state.  */
-/* Read a lookahead token if we need one and don't already have one.  */
-/* yyresume: */
+  /* Do appropriate processing given the current state.  Read a
+     lookahead token if we need one and don't already have one.  */
 
   /* First try to decide what to do without reference to lookahead token.  */
-
   yyn = yypact[yystate];
-  if (yyn == YYPACT_NINF)
+  if (yypact_value_is_default (yyn))
     goto yydefault;
 
   /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid lookahead symbol.  */
+  /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
   if (yychar == YYEMPTY)
     {
-      YYDPRINTF ((stderr, "Reading a token: "));
-      yychar = YYLEX;
+      YYDPRINTF ((stderr, "Reading a token\n"));
+      yychar = yylex (&yylval);
     }
 
   if (yychar <= YYEOF)
     {
-      yychar = yytoken = YYEOF;
+      yychar = YYEOF;
+      yytoken = YYSYMBOL_YYEOF;
       YYDPRINTF ((stderr, "Now at end of input.\n"));
+    }
+  else if (yychar == YYerror)
+    {
+      /* The scanner already issued an error message, process directly
+         to error recovery.  But do not keep the error token as
+         lookahead, it is too special and may lead us to an endless
+         loop in error recovery. */
+      yychar = YYUNDEF;
+      yytoken = YYSYMBOL_YYerror;
+      goto yyerrlab1;
     }
   else
     {
       yytoken = YYTRANSLATE (yychar);
-      YYDSYMPRINTF ("Next token is", yytoken, &yylval, &yylloc);
+      YY_SYMBOL_PRINT ("Next token is", yytoken, &yylval, &yylloc);
     }
 
   /* If the proper action on seeing token YYTOKEN is to reduce or to
@@ -1134,31 +1222,26 @@ yybackup:
   yyn = yytable[yyn];
   if (yyn <= 0)
     {
-      if (yyn == 0 || yyn == YYTABLE_NINF)
-	goto yyerrlab;
+      if (yytable_value_is_error (yyn))
+        goto yyerrlab;
       yyn = -yyn;
       goto yyreduce;
     }
-
-  if (yyn == YYFINAL)
-    YYACCEPT;
-
-  /* Shift the lookahead token.  */
-  YYDPRINTF ((stderr, "Shifting token %s, ", yytname[yytoken]));
-
-  /* Discard the token being shifted unless it is eof.  */
-  if (yychar != YYEOF)
-    yychar = YYEMPTY;
-
-  *++yyvsp = yylval;
-
 
   /* Count tokens shifted since error; after three, turn off error
      status.  */
   if (yyerrstatus)
     yyerrstatus--;
 
+  /* Shift the lookahead token.  */
+  YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
   yystate = yyn;
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  *++yyvsp = yylval;
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
+
+  /* Discard the shifted token.  */
+  yychar = YYEMPTY;
   goto yynewstate;
 
 
@@ -1173,14 +1256,14 @@ yydefault:
 
 
 /*-----------------------------.
-| yyreduce -- Do a reduction.  |
+| yyreduce -- do a reduction.  |
 `-----------------------------*/
 yyreduce:
   /* yyn is the number of a rule to reduce with.  */
   yylen = yyr2[yyn];
 
   /* If YYLEN is nonzero, implement the default value of the action:
-     `$$ = $1'.
+     '$$ = $1'.
 
      Otherwise, the following line sets YYVAL to garbage.
      This behavior is undocumented and Bison
@@ -1193,165 +1276,183 @@ yyreduce:
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-        case 2:
-#line 57 "gram.y"
-    {
-           ((SyckParser *)parser)->root = syck_hdlr_add_node( (SyckParser *)parser, yyvsp[0].nodeData );
+  case 2: /* doc: atom  */
+#line 58 "gram.y"
+        {
+           ((SyckParser *)parser)->root = syck_hdlr_add_node( (SyckParser *)parser, (yyvsp[0].nodeData) );
         }
+#line 1285 "gram.c"
     break;
 
-  case 3:
-#line 61 "gram.y"
-    {
-           ((SyckParser *)parser)->root = syck_hdlr_add_node( (SyckParser *)parser, yyvsp[0].nodeData );
+  case 3: /* doc: YAML_DOCSEP atom_or_empty  */
+#line 62 "gram.y"
+        {
+           ((SyckParser *)parser)->root = syck_hdlr_add_node( (SyckParser *)parser, (yyvsp[0].nodeData) );
         }
+#line 1293 "gram.c"
     break;
 
-  case 4:
-#line 65 "gram.y"
-    {
+  case 4: /* doc: %empty  */
+#line 66 "gram.y"
+        {
            ((SyckParser *)parser)->eof = 1;
         }
+#line 1301 "gram.c"
     break;
 
-  case 8:
-#line 76 "gram.y"
-    {
-            syck_add_transfer( yyvsp[-1].name, yyvsp[0].nodeData, ((SyckParser *)parser)->taguri_expansion );
-            yyval.nodeData = yyvsp[0].nodeData;
+  case 8: /* ind_rep: YAML_TRANSFER ind_rep  */
+#line 77 "gram.y"
+        { 
+            syck_add_transfer( (yyvsp[-1].name), (yyvsp[0].nodeData), ((SyckParser *)parser)->taguri_expansion );
+            (yyval.nodeData) = (yyvsp[0].nodeData);
         }
+#line 1310 "gram.c"
     break;
 
-  case 9:
-#line 81 "gram.y"
-    {
-            syck_add_transfer( yyvsp[-1].name, yyvsp[0].nodeData, 0 );
-            yyval.nodeData = yyvsp[0].nodeData;
+  case 9: /* ind_rep: YAML_TAGURI ind_rep  */
+#line 82 "gram.y"
+        {
+            syck_add_transfer( (yyvsp[-1].name), (yyvsp[0].nodeData), 0 );
+            (yyval.nodeData) = (yyvsp[0].nodeData);
         }
+#line 1319 "gram.c"
     break;
 
-  case 10:
-#line 86 "gram.y"
-    {
+  case 10: /* ind_rep: YAML_ANCHOR ind_rep  */
+#line 87 "gram.y"
+        { 
            /*
             * _Anchors_: The language binding must keep a separate symbol table
             * for anchors.  The actual ID in the symbol table is returned to the
             * higher nodes, though.
             */
-           yyval.nodeData = syck_hdlr_add_anchor( (SyckParser *)parser, yyvsp[-1].name, yyvsp[0].nodeData );
+           (yyval.nodeData) = syck_hdlr_add_anchor( (SyckParser *)parser, (yyvsp[-1].name), (yyvsp[0].nodeData) );
         }
+#line 1332 "gram.c"
     break;
 
-  case 11:
-#line 95 "gram.y"
-    {
-           yyval.nodeData = yyvsp[-1].nodeData;
+  case 11: /* ind_rep: indent_open ind_rep indent_flex_end  */
+#line 96 "gram.y"
+        {
+           (yyval.nodeData) = (yyvsp[-1].nodeData);
         }
+#line 1340 "gram.c"
     break;
 
-  case 14:
-#line 105 "gram.y"
-    {
-                    yyval.nodeData = yyvsp[-1].nodeData;
+  case 14: /* empty: indent_open empty indent_end  */
+#line 106 "gram.y"
+                {
+                    (yyval.nodeData) = (yyvsp[-1].nodeData);
                 }
+#line 1348 "gram.c"
     break;
 
-  case 15:
-#line 109 "gram.y"
-    {
+  case 15: /* empty: %empty  */
+#line 110 "gram.y"
+                {
                     NULL_NODE( parser, n );
-                    yyval.nodeData = n;
+                    (yyval.nodeData) = n;
                 }
+#line 1357 "gram.c"
     break;
 
-  case 16:
-#line 114 "gram.y"
-    {
+  case 16: /* empty: YAML_ITRANSFER empty  */
+#line 115 "gram.y"
+                { 
                    if ( ((SyckParser *)parser)->implicit_typing == 1 )
                    {
-                      try_tag_implicit( yyvsp[0].nodeData, ((SyckParser *)parser)->taguri_expansion );
+                      try_tag_implicit( (yyvsp[0].nodeData), ((SyckParser *)parser)->taguri_expansion );
                    }
-                   yyval.nodeData = yyvsp[0].nodeData;
+                   (yyval.nodeData) = (yyvsp[0].nodeData);
                 }
+#line 1369 "gram.c"
     break;
 
-  case 17:
-#line 122 "gram.y"
-    {
-                    syck_add_transfer( yyvsp[-1].name, yyvsp[0].nodeData, ((SyckParser *)parser)->taguri_expansion );
-                    yyval.nodeData = yyvsp[0].nodeData;
+  case 17: /* empty: YAML_TRANSFER empty  */
+#line 123 "gram.y"
+                { 
+                    syck_add_transfer( (yyvsp[-1].name), (yyvsp[0].nodeData), ((SyckParser *)parser)->taguri_expansion );
+                    (yyval.nodeData) = (yyvsp[0].nodeData);
                 }
+#line 1378 "gram.c"
     break;
 
-  case 18:
-#line 127 "gram.y"
-    {
-                    syck_add_transfer( yyvsp[-1].name, yyvsp[0].nodeData, 0 );
-                    yyval.nodeData = yyvsp[0].nodeData;
+  case 18: /* empty: YAML_TAGURI empty  */
+#line 128 "gram.y"
+                {
+                    syck_add_transfer( (yyvsp[-1].name), (yyvsp[0].nodeData), 0 );
+                    (yyval.nodeData) = (yyvsp[0].nodeData);
                 }
+#line 1387 "gram.c"
     break;
 
-  case 19:
-#line 132 "gram.y"
-    {
+  case 19: /* empty: YAML_ANCHOR empty  */
+#line 133 "gram.y"
+                { 
                    /*
                     * _Anchors_: The language binding must keep a separate symbol table
                     * for anchors.  The actual ID in the symbol table is returned to the
                     * higher nodes, though.
                     */
-                   yyval.nodeData = syck_hdlr_add_anchor( (SyckParser *)parser, yyvsp[-1].name, yyvsp[0].nodeData );
+                   (yyval.nodeData) = syck_hdlr_add_anchor( (SyckParser *)parser, (yyvsp[-1].name), (yyvsp[0].nodeData) );
                 }
+#line 1400 "gram.c"
     break;
 
-  case 26:
-#line 165 "gram.y"
-    {
-               syck_add_transfer( yyvsp[-1].name, yyvsp[0].nodeData, ((SyckParser *)parser)->taguri_expansion );
-               yyval.nodeData = yyvsp[0].nodeData;
+  case 26: /* word_rep: YAML_TRANSFER word_rep  */
+#line 166 "gram.y"
+            { 
+               syck_add_transfer( (yyvsp[-1].name), (yyvsp[0].nodeData), ((SyckParser *)parser)->taguri_expansion );
+               (yyval.nodeData) = (yyvsp[0].nodeData);
             }
+#line 1409 "gram.c"
     break;
 
-  case 27:
-#line 170 "gram.y"
-    {
-               syck_add_transfer( yyvsp[-1].name, yyvsp[0].nodeData, 0 );
-               yyval.nodeData = yyvsp[0].nodeData;
+  case 27: /* word_rep: YAML_TAGURI word_rep  */
+#line 171 "gram.y"
+            { 
+               syck_add_transfer( (yyvsp[-1].name), (yyvsp[0].nodeData), 0 );
+               (yyval.nodeData) = (yyvsp[0].nodeData);
             }
+#line 1418 "gram.c"
     break;
 
-  case 28:
-#line 175 "gram.y"
-    {
+  case 28: /* word_rep: YAML_ITRANSFER word_rep  */
+#line 176 "gram.y"
+            { 
                if ( ((SyckParser *)parser)->implicit_typing == 1 )
                {
-                  try_tag_implicit( yyvsp[0].nodeData, ((SyckParser *)parser)->taguri_expansion );
+                  try_tag_implicit( (yyvsp[0].nodeData), ((SyckParser *)parser)->taguri_expansion );
                }
-               yyval.nodeData = yyvsp[0].nodeData;
+               (yyval.nodeData) = (yyvsp[0].nodeData);
             }
+#line 1430 "gram.c"
     break;
 
-  case 29:
-#line 183 "gram.y"
-    {
-               yyval.nodeData = syck_hdlr_add_anchor( (SyckParser *)parser, yyvsp[-1].name, yyvsp[0].nodeData );
+  case 29: /* word_rep: YAML_ANCHOR word_rep  */
+#line 184 "gram.y"
+            { 
+               (yyval.nodeData) = syck_hdlr_add_anchor( (SyckParser *)parser, (yyvsp[-1].name), (yyvsp[0].nodeData) );
             }
+#line 1438 "gram.c"
     break;
 
-  case 30:
-#line 187 "gram.y"
-    {
+  case 30: /* word_rep: YAML_ALIAS  */
+#line 188 "gram.y"
+            {
                /*
                 * _Aliases_: The anchor symbol table is scanned for the anchor name.
                 * The anchor's ID in the language's symbol table is returned.
                 */
-               yyval.nodeData = syck_hdlr_get_anchor( (SyckParser *)parser, yyvsp[0].name );
+               (yyval.nodeData) = syck_hdlr_get_anchor( (SyckParser *)parser, (yyvsp[0].name) );
             }
+#line 1450 "gram.c"
     break;
 
-  case 31:
-#line 195 "gram.y"
-    {
-               SyckNode *n = yyvsp[0].nodeData;
+  case 31: /* word_rep: YAML_WORD  */
+#line 196 "gram.y"
+            { 
+               SyckNode *n = (yyvsp[0].nodeData);
                if ( ((SyckParser *)parser)->taguri_expansion == 1 )
                {
                    n->type_id = syck_taguri( YAML_DOMAIN, "str", 3 );
@@ -1360,417 +1461,393 @@ yyreduce:
                {
                    n->type_id = syck_strndup( "str", 3 );
                }
-               yyval.nodeData = n;
+               (yyval.nodeData) = n;
             }
+#line 1467 "gram.c"
     break;
 
-  case 33:
-#line 209 "gram.y"
-    {
-               yyval.nodeData = yyvsp[-1].nodeData;
+  case 33: /* word_rep: indent_open word_rep indent_flex_end  */
+#line 210 "gram.y"
+            {
+               (yyval.nodeData) = (yyvsp[-1].nodeData);
             }
+#line 1475 "gram.c"
     break;
 
-  case 39:
-#line 229 "gram.y"
-    {
-                    yyval.nodeData = yyvsp[-1].nodeData;
+  case 39: /* implicit_seq: indent_open top_imp_seq indent_end  */
+#line 230 "gram.y"
+                { 
+                    (yyval.nodeData) = (yyvsp[-1].nodeData);
                 }
+#line 1483 "gram.c"
     break;
 
-  case 40:
-#line 233 "gram.y"
-    {
-                    yyval.nodeData = yyvsp[-1].nodeData;
+  case 40: /* implicit_seq: indent_open in_implicit_seq indent_end  */
+#line 234 "gram.y"
+                { 
+                    (yyval.nodeData) = (yyvsp[-1].nodeData);
                 }
+#line 1491 "gram.c"
     break;
 
-  case 41:
-#line 239 "gram.y"
-    {
-                    yyval.nodeId = syck_hdlr_add_node( (SyckParser *)parser, yyvsp[0].nodeData );
+  case 41: /* basic_seq: '-' atom_or_empty  */
+#line 240 "gram.y"
+                { 
+                    (yyval.nodeId) = syck_hdlr_add_node( (SyckParser *)parser, (yyvsp[0].nodeData) );
                 }
+#line 1499 "gram.c"
     break;
 
-  case 42:
-#line 245 "gram.y"
-    {
-                    syck_add_transfer( yyvsp[-2].name, yyvsp[0].nodeData, ((SyckParser *)parser)->taguri_expansion );
-                    yyval.nodeData = yyvsp[0].nodeData;
+  case 42: /* top_imp_seq: YAML_TRANSFER indent_sep in_implicit_seq  */
+#line 246 "gram.y"
+                { 
+                    syck_add_transfer( (yyvsp[-2].name), (yyvsp[0].nodeData), ((SyckParser *)parser)->taguri_expansion );
+                    (yyval.nodeData) = (yyvsp[0].nodeData);
                 }
+#line 1508 "gram.c"
     break;
 
-  case 43:
-#line 250 "gram.y"
-    {
-                    syck_add_transfer( yyvsp[-1].name, yyvsp[0].nodeData, ((SyckParser *)parser)->taguri_expansion );
-                    yyval.nodeData = yyvsp[0].nodeData;
+  case 43: /* top_imp_seq: YAML_TRANSFER top_imp_seq  */
+#line 251 "gram.y"
+                { 
+                    syck_add_transfer( (yyvsp[-1].name), (yyvsp[0].nodeData), ((SyckParser *)parser)->taguri_expansion );
+                    (yyval.nodeData) = (yyvsp[0].nodeData);
                 }
+#line 1517 "gram.c"
     break;
 
-  case 44:
-#line 255 "gram.y"
-    {
-                    syck_add_transfer( yyvsp[-2].name, yyvsp[0].nodeData, 0 );
-                    yyval.nodeData = yyvsp[0].nodeData;
+  case 44: /* top_imp_seq: YAML_TAGURI indent_sep in_implicit_seq  */
+#line 256 "gram.y"
+                { 
+                    syck_add_transfer( (yyvsp[-2].name), (yyvsp[0].nodeData), 0 );
+                    (yyval.nodeData) = (yyvsp[0].nodeData);
                 }
+#line 1526 "gram.c"
     break;
 
-  case 45:
-#line 260 "gram.y"
-    {
-                    syck_add_transfer( yyvsp[-1].name, yyvsp[0].nodeData, 0 );
-                    yyval.nodeData = yyvsp[0].nodeData;
+  case 45: /* top_imp_seq: YAML_TAGURI top_imp_seq  */
+#line 261 "gram.y"
+                { 
+                    syck_add_transfer( (yyvsp[-1].name), (yyvsp[0].nodeData), 0 );
+                    (yyval.nodeData) = (yyvsp[0].nodeData);
                 }
+#line 1535 "gram.c"
     break;
 
-  case 46:
-#line 265 "gram.y"
-    {
-                    yyval.nodeData = syck_hdlr_add_anchor( (SyckParser *)parser, yyvsp[-2].name, yyvsp[0].nodeData );
+  case 46: /* top_imp_seq: YAML_ANCHOR indent_sep in_implicit_seq  */
+#line 266 "gram.y"
+                { 
+                    (yyval.nodeData) = syck_hdlr_add_anchor( (SyckParser *)parser, (yyvsp[-2].name), (yyvsp[0].nodeData) );
                 }
+#line 1543 "gram.c"
     break;
 
-  case 47:
-#line 269 "gram.y"
-    {
-                    yyval.nodeData = syck_hdlr_add_anchor( (SyckParser *)parser, yyvsp[-1].name, yyvsp[0].nodeData );
+  case 47: /* top_imp_seq: YAML_ANCHOR top_imp_seq  */
+#line 270 "gram.y"
+                { 
+                    (yyval.nodeData) = syck_hdlr_add_anchor( (SyckParser *)parser, (yyvsp[-1].name), (yyvsp[0].nodeData) );
                 }
+#line 1551 "gram.c"
     break;
 
-  case 48:
-#line 275 "gram.y"
-    {
-                    yyval.nodeData = syck_new_seq( yyvsp[0].nodeId );
+  case 48: /* in_implicit_seq: basic_seq  */
+#line 276 "gram.y"
+                {
+                    (yyval.nodeData) = syck_new_seq( (yyvsp[0].nodeId) );
                 }
+#line 1559 "gram.c"
     break;
 
-  case 49:
-#line 279 "gram.y"
-    {
-                    syck_seq_add( yyvsp[-2].nodeData, yyvsp[0].nodeId );
-                    yyval.nodeData = yyvsp[-2].nodeData;
+  case 49: /* in_implicit_seq: in_implicit_seq indent_sep basic_seq  */
+#line 280 "gram.y"
+                                { 
+                    syck_seq_add( (yyvsp[-2].nodeData), (yyvsp[0].nodeId) );
+                    (yyval.nodeData) = (yyvsp[-2].nodeData);
 				}
+#line 1568 "gram.c"
     break;
 
-  case 50:
-#line 284 "gram.y"
-    {
-                    yyval.nodeData = yyvsp[-1].nodeData;
+  case 50: /* in_implicit_seq: in_implicit_seq indent_sep  */
+#line 285 "gram.y"
+                                { 
+                    (yyval.nodeData) = (yyvsp[-1].nodeData);
 				}
+#line 1576 "gram.c"
     break;
 
-  case 51:
-#line 293 "gram.y"
-    {
-                    yyval.nodeData = yyvsp[-1].nodeData;
+  case 51: /* inline_seq: '[' in_inline_seq ']'  */
+#line 294 "gram.y"
+                { 
+                    (yyval.nodeData) = (yyvsp[-1].nodeData);
                 }
+#line 1584 "gram.c"
     break;
 
-  case 52:
-#line 297 "gram.y"
-    {
-                    yyval.nodeData = syck_alloc_seq();
+  case 52: /* inline_seq: '[' ']'  */
+#line 298 "gram.y"
+                { 
+                    (yyval.nodeData) = syck_alloc_seq();
                 }
+#line 1592 "gram.c"
     break;
 
-  case 53:
-#line 303 "gram.y"
-    {
-                    yyval.nodeData = syck_new_seq( syck_hdlr_add_node( (SyckParser *)parser, yyvsp[0].nodeData ) );
+  case 53: /* in_inline_seq: inline_seq_atom  */
+#line 304 "gram.y"
+                {
+                    (yyval.nodeData) = syck_new_seq( syck_hdlr_add_node( (SyckParser *)parser, (yyvsp[0].nodeData) ) );
                 }
+#line 1600 "gram.c"
     break;
 
-  case 54:
-#line 307 "gram.y"
-    {
-                    syck_seq_add( yyvsp[-2].nodeData, syck_hdlr_add_node( (SyckParser *)parser, yyvsp[0].nodeData ) );
-                    yyval.nodeData = yyvsp[-2].nodeData;
+  case 54: /* in_inline_seq: in_inline_seq ',' inline_seq_atom  */
+#line 308 "gram.y"
+                                { 
+                    syck_seq_add( (yyvsp[-2].nodeData), syck_hdlr_add_node( (SyckParser *)parser, (yyvsp[0].nodeData) ) );
+                    (yyval.nodeData) = (yyvsp[-2].nodeData);
 				}
+#line 1609 "gram.c"
     break;
 
-  case 57:
-#line 321 "gram.y"
-    {
-                    apply_seq_in_map( (SyckParser *)parser, yyvsp[-1].nodeData );
-                    yyval.nodeData = yyvsp[-1].nodeData;
+  case 57: /* implicit_map: indent_open top_imp_map indent_end  */
+#line 322 "gram.y"
+                { 
+                    apply_seq_in_map( (SyckParser *)parser, (yyvsp[-1].nodeData) );
+                    (yyval.nodeData) = (yyvsp[-1].nodeData);
                 }
+#line 1618 "gram.c"
     break;
 
-  case 58:
-#line 326 "gram.y"
-    {
-                    apply_seq_in_map( (SyckParser *)parser, yyvsp[-1].nodeData );
-                    yyval.nodeData = yyvsp[-1].nodeData;
+  case 58: /* implicit_map: indent_open in_implicit_map indent_end  */
+#line 327 "gram.y"
+                { 
+                    apply_seq_in_map( (SyckParser *)parser, (yyvsp[-1].nodeData) );
+                    (yyval.nodeData) = (yyvsp[-1].nodeData);
                 }
+#line 1627 "gram.c"
     break;
 
-  case 59:
-#line 333 "gram.y"
-    {
-                    syck_add_transfer( yyvsp[-2].name, yyvsp[0].nodeData, ((SyckParser *)parser)->taguri_expansion );
-                    yyval.nodeData = yyvsp[0].nodeData;
+  case 59: /* top_imp_map: YAML_TRANSFER indent_sep in_implicit_map  */
+#line 334 "gram.y"
+                { 
+                    syck_add_transfer( (yyvsp[-2].name), (yyvsp[0].nodeData), ((SyckParser *)parser)->taguri_expansion );
+                    (yyval.nodeData) = (yyvsp[0].nodeData);
                 }
+#line 1636 "gram.c"
     break;
 
-  case 60:
-#line 338 "gram.y"
-    {
-                    syck_add_transfer( yyvsp[-1].name, yyvsp[0].nodeData, ((SyckParser *)parser)->taguri_expansion );
-                    yyval.nodeData = yyvsp[0].nodeData;
+  case 60: /* top_imp_map: YAML_TRANSFER top_imp_map  */
+#line 339 "gram.y"
+                { 
+                    syck_add_transfer( (yyvsp[-1].name), (yyvsp[0].nodeData), ((SyckParser *)parser)->taguri_expansion );
+                    (yyval.nodeData) = (yyvsp[0].nodeData);
                 }
+#line 1645 "gram.c"
     break;
 
-  case 61:
-#line 343 "gram.y"
-    {
-                    syck_add_transfer( yyvsp[-2].name, yyvsp[0].nodeData, 0 );
-                    yyval.nodeData = yyvsp[0].nodeData;
+  case 61: /* top_imp_map: YAML_TAGURI indent_sep in_implicit_map  */
+#line 344 "gram.y"
+                { 
+                    syck_add_transfer( (yyvsp[-2].name), (yyvsp[0].nodeData), 0 );
+                    (yyval.nodeData) = (yyvsp[0].nodeData);
                 }
+#line 1654 "gram.c"
     break;
 
-  case 62:
-#line 348 "gram.y"
-    {
-                    syck_add_transfer( yyvsp[-1].name, yyvsp[0].nodeData, 0 );
-                    yyval.nodeData = yyvsp[0].nodeData;
+  case 62: /* top_imp_map: YAML_TAGURI top_imp_map  */
+#line 349 "gram.y"
+                { 
+                    syck_add_transfer( (yyvsp[-1].name), (yyvsp[0].nodeData), 0 );
+                    (yyval.nodeData) = (yyvsp[0].nodeData);
                 }
+#line 1663 "gram.c"
     break;
 
-  case 63:
-#line 353 "gram.y"
-    {
-                    yyval.nodeData = syck_hdlr_add_anchor( (SyckParser *)parser, yyvsp[-2].name, yyvsp[0].nodeData );
+  case 63: /* top_imp_map: YAML_ANCHOR indent_sep in_implicit_map  */
+#line 354 "gram.y"
+                { 
+                    (yyval.nodeData) = syck_hdlr_add_anchor( (SyckParser *)parser, (yyvsp[-2].name), (yyvsp[0].nodeData) );
                 }
+#line 1671 "gram.c"
     break;
 
-  case 64:
-#line 357 "gram.y"
-    {
-                    yyval.nodeData = syck_hdlr_add_anchor( (SyckParser *)parser, yyvsp[-1].name, yyvsp[0].nodeData );
+  case 64: /* top_imp_map: YAML_ANCHOR top_imp_map  */
+#line 358 "gram.y"
+                { 
+                    (yyval.nodeData) = syck_hdlr_add_anchor( (SyckParser *)parser, (yyvsp[-1].name), (yyvsp[0].nodeData) );
                 }
+#line 1679 "gram.c"
     break;
 
-  case 66:
-#line 364 "gram.y"
-    {
-                    yyval.nodeData = yyvsp[-1].nodeData;
+  case 66: /* complex_key: '?' atom indent_sep  */
+#line 365 "gram.y"
+                {
+                    (yyval.nodeData) = (yyvsp[-1].nodeData);
                 }
+#line 1687 "gram.c"
     break;
 
-  case 68:
-#line 380 "gram.y"
-    {
-                    yyval.nodeData = syck_new_map(
-                        syck_hdlr_add_node( (SyckParser *)parser, yyvsp[-2].nodeData ),
-                        syck_hdlr_add_node( (SyckParser *)parser, yyvsp[0].nodeData ) );
+  case 68: /* complex_mapping: complex_key ':' complex_value  */
+#line 381 "gram.y"
+                {
+                    (yyval.nodeData) = syck_new_map( 
+                        syck_hdlr_add_node( (SyckParser *)parser, (yyvsp[-2].nodeData) ), 
+                        syck_hdlr_add_node( (SyckParser *)parser, (yyvsp[0].nodeData) ) );
                 }
+#line 1697 "gram.c"
     break;
 
-  case 70:
-#line 398 "gram.y"
-    {
-                    if ( yyvsp[-2].nodeData->shortcut == NULL )
+  case 70: /* in_implicit_map: in_implicit_map indent_sep basic_seq  */
+#line 399 "gram.y"
+                {
+                    if ( (yyvsp[-2].nodeData)->shortcut == NULL )
                     {
-                        yyvsp[-2].nodeData->shortcut = syck_new_seq( yyvsp[0].nodeId );
+                        (yyvsp[-2].nodeData)->shortcut = syck_new_seq( (yyvsp[0].nodeId) );
                     }
                     else
                     {
-                        syck_seq_add( yyvsp[-2].nodeData->shortcut, yyvsp[0].nodeId );
+                        syck_seq_add( (yyvsp[-2].nodeData)->shortcut, (yyvsp[0].nodeId) );
                     }
-                    yyval.nodeData = yyvsp[-2].nodeData;
+                    (yyval.nodeData) = (yyvsp[-2].nodeData);
                 }
+#line 1713 "gram.c"
     break;
 
-  case 71:
-#line 410 "gram.y"
-    {
-                    apply_seq_in_map( (SyckParser *)parser, yyvsp[-2].nodeData );
-                    syck_map_update( yyvsp[-2].nodeData, yyvsp[0].nodeData );
-                    syck_free_node( yyvsp[0].nodeData );
-                    yyvsp[0].nodeData = NULL;
-                    yyval.nodeData = yyvsp[-2].nodeData;
+  case 71: /* in_implicit_map: in_implicit_map indent_sep complex_mapping  */
+#line 411 "gram.y"
+                {
+                    apply_seq_in_map( (SyckParser *)parser, (yyvsp[-2].nodeData) );
+                    syck_map_update( (yyvsp[-2].nodeData), (yyvsp[0].nodeData) );
+                    syck_free_node( (yyvsp[0].nodeData) );
+                    (yyvsp[0].nodeData) = NULL;
+                    (yyval.nodeData) = (yyvsp[-2].nodeData);
                 }
+#line 1725 "gram.c"
     break;
 
-  case 72:
-#line 418 "gram.y"
-    {
-                    yyval.nodeData = yyvsp[-1].nodeData;
+  case 72: /* in_implicit_map: in_implicit_map indent_sep  */
+#line 419 "gram.y"
+                {
+                    (yyval.nodeData) = (yyvsp[-1].nodeData);
                 }
+#line 1733 "gram.c"
     break;
 
-  case 73:
-#line 427 "gram.y"
-    {
-                    yyval.nodeData = syck_new_map(
-                        syck_hdlr_add_node( (SyckParser *)parser, yyvsp[-2].nodeData ),
-                        syck_hdlr_add_node( (SyckParser *)parser, yyvsp[0].nodeData ) );
+  case 73: /* basic_mapping: atom ':' atom_or_empty  */
+#line 428 "gram.y"
+                {
+                    (yyval.nodeData) = syck_new_map( 
+                        syck_hdlr_add_node( (SyckParser *)parser, (yyvsp[-2].nodeData) ), 
+                        syck_hdlr_add_node( (SyckParser *)parser, (yyvsp[0].nodeData) ) );
                 }
+#line 1743 "gram.c"
     break;
 
-  case 74:
-#line 435 "gram.y"
-    {
-                    yyval.nodeData = yyvsp[-1].nodeData;
+  case 74: /* inline_map: '{' in_inline_map '}'  */
+#line 436 "gram.y"
+                {
+                    (yyval.nodeData) = (yyvsp[-1].nodeData);
                 }
+#line 1751 "gram.c"
     break;
 
-  case 75:
-#line 439 "gram.y"
-    {
-                    yyval.nodeData = syck_alloc_map();
+  case 75: /* inline_map: '{' '}'  */
+#line 440 "gram.y"
+                {
+                    (yyval.nodeData) = syck_alloc_map();
                 }
+#line 1759 "gram.c"
     break;
 
-  case 77:
-#line 446 "gram.y"
-    {
-                    syck_map_update( yyvsp[-2].nodeData, yyvsp[0].nodeData );
-                    syck_free_node( yyvsp[0].nodeData );
-                    yyvsp[0].nodeData = NULL;
-                    yyval.nodeData = yyvsp[-2].nodeData;
+  case 77: /* in_inline_map: in_inline_map ',' inline_map_atom  */
+#line 447 "gram.y"
+                                {
+                    syck_map_update( (yyvsp[-2].nodeData), (yyvsp[0].nodeData) );
+                    syck_free_node( (yyvsp[0].nodeData) );
+                    (yyvsp[0].nodeData) = NULL;
+                    (yyval.nodeData) = (yyvsp[-2].nodeData);
 				}
+#line 1770 "gram.c"
     break;
 
-  case 78:
-#line 455 "gram.y"
-    {
+  case 78: /* inline_map_atom: atom  */
+#line 456 "gram.y"
+                {
                     NULL_NODE( parser, n );
-                    yyval.nodeData = syck_new_map(
-                        syck_hdlr_add_node( (SyckParser *)parser, yyvsp[0].nodeData ),
+                    (yyval.nodeData) = syck_new_map( 
+                        syck_hdlr_add_node( (SyckParser *)parser, (yyvsp[0].nodeData) ), 
                         syck_hdlr_add_node( (SyckParser *)parser, n ) );
                 }
+#line 1781 "gram.c"
     break;
 
 
+#line 1785 "gram.c"
+
+      default: break;
     }
+  /* User semantic actions sometimes alter yychar, and that requires
+     that yytoken be updated with the new translation.  We take the
+     approach of translating immediately before every use of yytoken.
+     One alternative is translating here after every semantic action,
+     but that translation would be missed if the semantic action invokes
+     YYABORT, YYACCEPT, or YYERROR immediately after altering yychar or
+     if it invokes YYBACKUP.  In the case of YYABORT or YYACCEPT, an
+     incorrect destructor might then be invoked immediately.  In the
+     case of YYERROR or YYBACKUP, subsequent parser actions might lead
+     to an incorrect destructor call or verbose syntax error message
+     before the lookahead is translated.  */
+  YY_SYMBOL_PRINT ("-> $$ =", YY_CAST (yysymbol_kind_t, yyr1[yyn]), &yyval, &yyloc);
 
-/* Line 1010 of yacc.c.  */
-#line 1651 "gram.c"
-
-  yyvsp -= yylen;
-  yyssp -= yylen;
-
-
-  YY_STACK_PRINT (yyss, yyssp);
+  YYPOPSTACK (yylen);
+  yylen = 0;
 
   *++yyvsp = yyval;
 
-
-  /* Now `shift' the result of the reduction.  Determine what state
+  /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
-
-  yyn = yyr1[yyn];
-
-  yystate = yypgoto[yyn - YYNTOKENS] + *yyssp;
-  if (0 <= yystate && yystate <= YYLAST && yycheck[yystate] == *yyssp)
-    yystate = yytable[yystate];
-  else
-    yystate = yydefgoto[yyn - YYNTOKENS];
+  {
+    const int yylhs = yyr1[yyn] - YYNTOKENS;
+    const int yyi = yypgoto[yylhs] + *yyssp;
+    yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
+               ? yytable[yyi]
+               : yydefgoto[yylhs]);
+  }
 
   goto yynewstate;
 
 
-/*------------------------------------.
-| yyerrlab -- here on detecting error |
-`------------------------------------*/
+/*--------------------------------------.
+| yyerrlab -- here on detecting error.  |
+`--------------------------------------*/
 yyerrlab:
+  /* Make sure we have latest lookahead translation.  See comments at
+     user semantic actions for why this is necessary.  */
+  yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)
     {
       ++yynerrs;
-#if YYERROR_VERBOSE
-      yyn = yypact[yystate];
-
-      if (YYPACT_NINF < yyn && yyn < YYLAST)
-	{
-	  YYSIZE_T yysize = 0;
-	  int yytype = YYTRANSLATE (yychar);
-	  const char* yyprefix;
-	  char *yymsg;
-	  int yyx;
-
-	  /* Start YYX at -YYN if negative to avoid negative indexes in
-	     YYCHECK.  */
-	  int yyxbegin = yyn < 0 ? -yyn : 0;
-
-	  /* Stay within bounds of both yycheck and yytname.  */
-	  int yychecklim = YYLAST - yyn;
-	  int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-	  int yycount = 0;
-
-	  yyprefix = ", expecting ";
-	  for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-	    if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR)
-	      {
-		yysize += yystrlen (yyprefix) + yystrlen (yytname [yyx]);
-		yycount += 1;
-		if (yycount == 5)
-		  {
-		    yysize = 0;
-		    break;
-		  }
-	      }
-	  yysize += (sizeof ("syntax error, unexpected ")
-		     + yystrlen (yytname[yytype]));
-	  yymsg = (char *) YYSTACK_ALLOC (yysize);
-	  if (yymsg != 0)
-	    {
-	      char *yyp = yystpcpy (yymsg, "syntax error, unexpected ");
-	      yyp = yystpcpy (yyp, yytname[yytype]);
-
-	      if (yycount < 5)
-		{
-		  yyprefix = ", expecting ";
-		  for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-		    if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR)
-		      {
-			yyp = yystpcpy (yyp, yyprefix);
-			yyp = yystpcpy (yyp, yytname[yyx]);
-			yyprefix = " or ";
-		      }
-		}
-	      yyerror (yymsg);
-	      YYSTACK_FREE (yymsg);
-	    }
-	  else
-	    yyerror ("syntax error; also virtual memory exhausted");
-	}
-      else
-#endif /* YYERROR_VERBOSE */
-	yyerror ("syntax error");
+      yyerror (YYPARSE_PARAM, YY_("syntax error"));
     }
-
-
 
   if (yyerrstatus == 3)
     {
       /* If just tried and failed to reuse lookahead token after an
-	 error, discard it.  */
+         error, discard it.  */
 
       if (yychar <= YYEOF)
         {
-          /* If at end of input, pop the error token,
-	     then the rest of the stack, then return failure.  */
-	  if (yychar == YYEOF)
-	     for (;;)
-	       {
-		 YYPOPSTACK;
-		 if (yyssp == yyss)
-		   YYABORT;
-		 YYDSYMPRINTF ("Error: popping", yystos[*yyssp], yyvsp, yylsp);
-		 yydestruct (yystos[*yyssp], yyvsp);
-	       }
+          /* Return failure if at end of input.  */
+          if (yychar == YYEOF)
+            YYABORT;
         }
       else
-	{
-	  YYDSYMPRINTF ("Error: discarding", yytoken, &yylval, &yylloc);
-	  yydestruct (yytoken, &yylval);
-	  yychar = YYEMPTY;
-
-	}
+        {
+          yydestruct ("Error: discarding",
+                      yytoken, &yylval, YYPARSE_PARAM);
+          yychar = YYEMPTY;
+        }
     }
 
   /* Else will try to reuse lookahead token after shifting the error
@@ -1782,16 +1859,17 @@ yyerrlab:
 | yyerrorlab -- error raised explicitly by YYERROR.  |
 `---------------------------------------------------*/
 yyerrorlab:
-
-#ifdef __GNUC__
-  /* Pacify GCC when the user code never invokes YYERROR and the label
-     yyerrorlab therefore never appears in user code.  */
+  /* Pacify compilers when the user code never invokes YYERROR and the
+     label yyerrorlab therefore never appears in user code.  */
   if (0)
-     goto yyerrorlab;
-#endif
+    YYERROR;
+  ++yynerrs;
 
-  yyvsp -= yylen;
-  yyssp -= yylen;
+  /* Do not reclaim the symbols of the rule whose action triggered
+     this YYERROR.  */
+  YYPOPSTACK (yylen);
+  yylen = 0;
+  YY_STACK_PRINT (yyss, yyssp);
   yystate = *yyssp;
   goto yyerrlab1;
 
@@ -1800,40 +1878,42 @@ yyerrorlab:
 | yyerrlab1 -- common code for both syntax error and YYERROR.  |
 `-------------------------------------------------------------*/
 yyerrlab1:
-  yyerrstatus = 3;	/* Each real token shifted decrements this.  */
+  yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
+  /* Pop stack until we find a state that shifts the error token.  */
   for (;;)
     {
       yyn = yypact[yystate];
-      if (yyn != YYPACT_NINF)
-	{
-	  yyn += YYTERROR;
-	  if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
-	    {
-	      yyn = yytable[yyn];
-	      if (0 < yyn)
-		break;
-	    }
-	}
+      if (!yypact_value_is_default (yyn))
+        {
+          yyn += YYSYMBOL_YYerror;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYerror)
+            {
+              yyn = yytable[yyn];
+              if (0 < yyn)
+                break;
+            }
+        }
 
       /* Pop the current state because it cannot handle the error token.  */
       if (yyssp == yyss)
-	YYABORT;
+        YYABORT;
 
-      YYDSYMPRINTF ("Error: popping", yystos[*yyssp], yyvsp, yylsp);
-      yydestruct (yystos[yystate], yyvsp);
-      YYPOPSTACK;
+
+      yydestruct ("Error: popping",
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp, YYPARSE_PARAM);
+      YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
     }
 
-  if (yyn == YYFINAL)
-    YYACCEPT;
-
-  YYDPRINTF ((stderr, "Shifting error token, "));
-
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 
+
+  /* Shift the error token.  */
+  YY_SYMBOL_PRINT ("Shifting", YY_ACCESSING_SYMBOL (yyn), yyvsp, yylsp);
 
   yystate = yyn;
   goto yynewstate;
@@ -1844,35 +1924,57 @@ yyerrlab1:
 `-------------------------------------*/
 yyacceptlab:
   yyresult = 0;
-  goto yyreturn;
+  goto yyreturnlab;
+
 
 /*-----------------------------------.
 | yyabortlab -- YYABORT comes here.  |
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
-  goto yyreturn;
+  goto yyreturnlab;
 
-#ifndef yyoverflow
-/*----------------------------------------------.
-| yyoverflowlab -- parser overflow comes here.  |
-`----------------------------------------------*/
-yyoverflowlab:
-  yyerror ("parser stack overflow");
+
+/*-----------------------------------------------------------.
+| yyexhaustedlab -- YYNOMEM (memory exhaustion) comes here.  |
+`-----------------------------------------------------------*/
+yyexhaustedlab:
+  yyerror (YYPARSE_PARAM, YY_("memory exhausted"));
   yyresult = 2;
-  /* Fall through.  */
-#endif
+  goto yyreturnlab;
 
-yyreturn:
+
+/*----------------------------------------------------------.
+| yyreturnlab -- parsing is finished, clean up and return.  |
+`----------------------------------------------------------*/
+yyreturnlab:
+  if (yychar != YYEMPTY)
+    {
+      /* Make sure we have latest lookahead translation.  See comments at
+         user semantic actions for why this is necessary.  */
+      yytoken = YYTRANSLATE (yychar);
+      yydestruct ("Cleanup: discarding lookahead",
+                  yytoken, &yylval, YYPARSE_PARAM);
+    }
+  /* Do not reclaim the symbols of the rule whose action triggered
+     this YYABORT or YYACCEPT.  */
+  YYPOPSTACK (yylen);
+  YY_STACK_PRINT (yyss, yyssp);
+  while (yyssp != yyss)
+    {
+      yydestruct ("Cleanup: popping",
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, YYPARSE_PARAM);
+      YYPOPSTACK (1);
+    }
 #ifndef yyoverflow
   if (yyss != yyssa)
     YYSTACK_FREE (yyss);
 #endif
+
   return yyresult;
 }
 
-
-#line 464 "gram.y"
+#line 465 "gram.y"
 
 
 void
@@ -1890,5 +1992,3 @@ apply_seq_in_map( SyckParser *parser, SyckNode *n )
 
     n->shortcut = NULL;
 }
-
-

--- a/ext/syck/gram.h
+++ b/ext/syck/gram.h
@@ -1,12 +1,14 @@
-/* A Bison parser, made by GNU Bison 1.875d.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
-/* Skeleton parser for Yacc-like parsing with Bison,
-   Copyright (C) 1984, 1989, 1990, 2000, 2001, 2002, 2003, 2004 Free Software Foundation, Inc.
+/* Bison interface for Yacc-like parsers in C
 
-   This program is free software; you can redistribute it and/or modify
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+   Inc.
+
+   This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2, or (at your option)
-   any later version.
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
 
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,66 +16,82 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 59 Temple Place - Suite 330,
-   Boston, MA 02111-1307, USA.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
-/* As a special exception, when this file is copied by Bison into a
-   Bison output file, you may use that output file without restriction.
-   This special exception was added by the Free Software Foundation
-   in version 1.24 of Bison.  */
+/* As a special exception, you may create a larger work that contains
+   part or all of the Bison parser skeleton and distribute that work
+   under terms of your choice, so long as that work isn't itself a
+   parser generator using the skeleton or a modified version thereof
+   as a parser skeleton.  Alternatively, if you modify or redistribute
+   the parser skeleton itself, you may (at your option) remove this
+   special exception, which will cause the skeleton and the resulting
+   Bison output files to be licensed under the GNU General Public
+   License without this special exception.
 
-/* Tokens.  */
+   This special exception was added by the Free Software Foundation in
+   version 2.2 of Bison.  */
+
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
+#ifndef YY_YY_GRAM_H_INCLUDED
+# define YY_YY_GRAM_H_INCLUDED
+/* Debug traces.  */
+#ifndef YYDEBUG
+# define YYDEBUG 0
+#endif
+#if YYDEBUG
+extern int yydebug;
+#endif
+
+/* Token kinds.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
-   /* Put the tokens into the symbol table, so that GDB and other debuggers
-      know about them.  */
-   enum yytokentype {
-     YAML_ANCHOR = 258,
-     YAML_ALIAS = 259,
-     YAML_TRANSFER = 260,
-     YAML_TAGURI = 261,
-     YAML_ITRANSFER = 262,
-     YAML_WORD = 263,
-     YAML_PLAIN = 264,
-     YAML_BLOCK = 265,
-     YAML_DOCSEP = 266,
-     YAML_IOPEN = 267,
-     YAML_INDENT = 268,
-     YAML_IEND = 269
-   };
+  enum yytokentype
+  {
+    YYEMPTY = -2,
+    YYEOF = 0,                     /* "end of file"  */
+    YYerror = 256,                 /* error  */
+    YYUNDEF = 257,                 /* "invalid token"  */
+    YAML_ANCHOR = 258,             /* YAML_ANCHOR  */
+    YAML_ALIAS = 259,              /* YAML_ALIAS  */
+    YAML_TRANSFER = 260,           /* YAML_TRANSFER  */
+    YAML_TAGURI = 261,             /* YAML_TAGURI  */
+    YAML_ITRANSFER = 262,          /* YAML_ITRANSFER  */
+    YAML_WORD = 263,               /* YAML_WORD  */
+    YAML_PLAIN = 264,              /* YAML_PLAIN  */
+    YAML_BLOCK = 265,              /* YAML_BLOCK  */
+    YAML_DOCSEP = 266,             /* YAML_DOCSEP  */
+    YAML_IOPEN = 267,              /* YAML_IOPEN  */
+    YAML_INDENT = 268,             /* YAML_INDENT  */
+    YAML_IEND = 269                /* YAML_IEND  */
+  };
+  typedef enum yytokentype yytoken_kind_t;
 #endif
-#define YAML_ANCHOR 258
-#define YAML_ALIAS 259
-#define YAML_TRANSFER 260
-#define YAML_TAGURI 261
-#define YAML_ITRANSFER 262
-#define YAML_WORD 263
-#define YAML_PLAIN 264
-#define YAML_BLOCK 265
-#define YAML_DOCSEP 266
-#define YAML_IOPEN 267
-#define YAML_INDENT 268
-#define YAML_IEND 269
 
-
-
-
-#if ! defined (YYSTYPE) && ! defined (YYSTYPE_IS_DECLARED)
+/* Value type.  */
+#if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
+union YYSTYPE
+{
 #line 35 "gram.y"
-typedef union YYSTYPE {
+
     SYMID nodeId;
     SyckNode *nodeData;
     char *name;
-} YYSTYPE;
-/* Line 1285 of yacc.c.  */
-#line 71 "gram.h"
-# define yystype YYSTYPE /* obsolescent; will be withdrawn */
-# define YYSTYPE_IS_DECLARED 1
+
+#line 84 "gram.h"
+
+};
+typedef union YYSTYPE YYSTYPE;
 # define YYSTYPE_IS_TRIVIAL 1
+# define YYSTYPE_IS_DECLARED 1
 #endif
 
 
 
 
+int yyparse (void *YYPARSE_PARAM);
 
+
+#endif /* !YY_YY_GRAM_H_INCLUDED  */

--- a/ext/syck/gram.y
+++ b/ext/syck/gram.y
@@ -1,0 +1,481 @@
+%start doc
+%define api.pure
+
+%{
+
+#define YYDEBUG 1
+#define YYERROR_VERBOSE 1
+#ifndef YYSTACK_USE_ALLOCA
+#define YYSTACK_USE_ALLOCA 0
+#endif
+
+#include "syck.h"
+
+void apply_seq_in_map( SyckParser *parser, SyckNode *n );
+
+#define YYPARSE_PARAM parser
+#define YYLEX_PARAM   parser
+
+#define yyparse           syckparse
+#define yylex(yylval)     sycklex(yylval, YYLEX_PARAM)
+#define yyerror(_, error) syckerror(error)
+
+#define NULL_NODE(parser, node) \
+        SyckNode *node = syck_new_str( "", scalar_plain ); \
+        if ( ((SyckParser *)parser)->taguri_expansion == 1 ) \
+        { \
+            node->type_id = syck_taguri( YAML_DOMAIN, "null", 4 ); \
+        } \
+        else \
+        { \
+            node->type_id = syck_strndup( "null", 4 ); \
+        }
+%}
+
+%union {
+    SYMID nodeId;
+    SyckNode *nodeData;
+    char *name;
+};
+
+%token <name>       YAML_ANCHOR YAML_ALIAS YAML_TRANSFER YAML_TAGURI YAML_ITRANSFER
+%token <nodeData>   YAML_WORD YAML_PLAIN YAML_BLOCK
+%token              YAML_DOCSEP YAML_IOPEN YAML_INDENT YAML_IEND
+
+%type <nodeId>      doc basic_seq
+%type <nodeData>    atom word_rep ind_rep struct_rep atom_or_empty empty
+%type <nodeData>    implicit_seq inline_seq implicit_map inline_map inline_seq_atom inline_map_atom
+%type <nodeData>    top_imp_seq in_implicit_seq in_inline_seq basic_mapping complex_key complex_value
+%type <nodeData>    top_imp_map in_implicit_map in_inline_map complex_mapping
+
+%left               '-' ':'
+%left               '[' ']' '{' '}' ',' '?'
+%parse-param {void *YYPARSE_PARAM}
+
+%%
+
+doc     : atom
+        {
+           ((SyckParser *)parser)->root = syck_hdlr_add_node( (SyckParser *)parser, $1 );
+        }
+        | YAML_DOCSEP atom_or_empty
+        {
+           ((SyckParser *)parser)->root = syck_hdlr_add_node( (SyckParser *)parser, $2 );
+        }
+        |
+        {
+           ((SyckParser *)parser)->eof = 1;
+        }
+        ;
+
+atom	: word_rep
+        | ind_rep
+        ;
+
+ind_rep : struct_rep
+        | YAML_TRANSFER ind_rep
+        { 
+            syck_add_transfer( $1, $2, ((SyckParser *)parser)->taguri_expansion );
+            $$ = $2;
+        }
+        | YAML_TAGURI ind_rep
+        {
+            syck_add_transfer( $1, $2, 0 );
+            $$ = $2;
+        }
+        | YAML_ANCHOR ind_rep
+        { 
+           /*
+            * _Anchors_: The language binding must keep a separate symbol table
+            * for anchors.  The actual ID in the symbol table is returned to the
+            * higher nodes, though.
+            */
+           $$ = syck_hdlr_add_anchor( (SyckParser *)parser, $1, $2 );
+        }
+        | indent_open ind_rep indent_flex_end
+        {
+           $$ = $2;
+        }
+        ;
+
+atom_or_empty   : atom
+                | empty
+                ;
+
+empty           : indent_open empty indent_end
+                {
+                    $$ = $2;
+                }
+                |
+                {
+                    NULL_NODE( parser, n );
+                    $$ = n;
+                }
+                | YAML_ITRANSFER empty
+                { 
+                   if ( ((SyckParser *)parser)->implicit_typing == 1 )
+                   {
+                      try_tag_implicit( $2, ((SyckParser *)parser)->taguri_expansion );
+                   }
+                   $$ = $2;
+                }
+                | YAML_TRANSFER empty
+                { 
+                    syck_add_transfer( $1, $2, ((SyckParser *)parser)->taguri_expansion );
+                    $$ = $2;
+                }
+                | YAML_TAGURI empty
+                {
+                    syck_add_transfer( $1, $2, 0 );
+                    $$ = $2;
+                }
+                | YAML_ANCHOR empty
+                { 
+                   /*
+                    * _Anchors_: The language binding must keep a separate symbol table
+                    * for anchors.  The actual ID in the symbol table is returned to the
+                    * higher nodes, though.
+                    */
+                   $$ = syck_hdlr_add_anchor( (SyckParser *)parser, $1, $2 );
+                }
+                ;
+
+/*
+ * Indentation abstractions
+ */
+indent_open     : YAML_IOPEN
+                | indent_open YAML_INDENT
+                ;
+                
+indent_end      : YAML_IEND
+                ;
+
+indent_sep      : YAML_INDENT
+                ;
+
+indent_flex_end : YAML_IEND
+                | indent_sep indent_flex_end
+                ;
+
+/*
+ * Words are broken out to distinguish them
+ * as keys in implicit maps and valid elements
+ * for the inline structures
+ */
+word_rep	: YAML_TRANSFER word_rep						
+            { 
+               syck_add_transfer( $1, $2, ((SyckParser *)parser)->taguri_expansion );
+               $$ = $2;
+            } 
+            | YAML_TAGURI word_rep
+            { 
+               syck_add_transfer( $1, $2, 0 );
+               $$ = $2;
+            } 
+            | YAML_ITRANSFER word_rep						
+            { 
+               if ( ((SyckParser *)parser)->implicit_typing == 1 )
+               {
+                  try_tag_implicit( $2, ((SyckParser *)parser)->taguri_expansion );
+               }
+               $$ = $2;
+            }
+            | YAML_ANCHOR word_rep
+            { 
+               $$ = syck_hdlr_add_anchor( (SyckParser *)parser, $1, $2 );
+            }
+            | YAML_ALIAS										
+            {
+               /*
+                * _Aliases_: The anchor symbol table is scanned for the anchor name.
+                * The anchor's ID in the language's symbol table is returned.
+                */
+               $$ = syck_hdlr_get_anchor( (SyckParser *)parser, $1 );
+            }
+			| YAML_WORD
+            { 
+               SyckNode *n = $1;
+               if ( ((SyckParser *)parser)->taguri_expansion == 1 )
+               {
+                   n->type_id = syck_taguri( YAML_DOMAIN, "str", 3 );
+               }
+               else
+               {
+                   n->type_id = syck_strndup( "str", 3 );
+               }
+               $$ = n;
+            }
+            | YAML_PLAIN
+            | indent_open word_rep indent_flex_end
+            {
+               $$ = $2;
+            }
+            ;
+
+/*
+ * Any of these structures can be used as
+ * complex keys
+ */
+struct_rep	: YAML_BLOCK
+			| implicit_seq
+			| inline_seq
+			| implicit_map
+			| inline_map
+            ;
+
+/*
+ * Implicit sequence 
+ */
+implicit_seq	: indent_open top_imp_seq indent_end
+                { 
+                    $$ = $2;
+                }
+                | indent_open in_implicit_seq indent_end
+                { 
+                    $$ = $2;
+                }
+                ;
+
+basic_seq       : '-' atom_or_empty             
+                { 
+                    $$ = syck_hdlr_add_node( (SyckParser *)parser, $2 );
+                }
+                ;
+
+top_imp_seq     : YAML_TRANSFER indent_sep in_implicit_seq
+                { 
+                    syck_add_transfer( $1, $3, ((SyckParser *)parser)->taguri_expansion );
+                    $$ = $3;
+                }
+                | YAML_TRANSFER top_imp_seq
+                { 
+                    syck_add_transfer( $1, $2, ((SyckParser *)parser)->taguri_expansion );
+                    $$ = $2;
+                }
+                | YAML_TAGURI indent_sep in_implicit_seq
+                { 
+                    syck_add_transfer( $1, $3, 0 );
+                    $$ = $3;
+                }
+                | YAML_TAGURI top_imp_seq
+                { 
+                    syck_add_transfer( $1, $2, 0 );
+                    $$ = $2;
+                }
+                | YAML_ANCHOR indent_sep in_implicit_seq
+                { 
+                    $$ = syck_hdlr_add_anchor( (SyckParser *)parser, $1, $3 );
+                }
+                | YAML_ANCHOR top_imp_seq
+                { 
+                    $$ = syck_hdlr_add_anchor( (SyckParser *)parser, $1, $2 );
+                }
+                ;
+
+in_implicit_seq : basic_seq
+                {
+                    $$ = syck_new_seq( $1 );
+                }
+				| in_implicit_seq indent_sep basic_seq
+				{ 
+                    syck_seq_add( $1, $3 );
+                    $$ = $1;
+				}
+				| in_implicit_seq indent_sep
+				{ 
+                    $$ = $1;
+				}
+                ;
+
+/*
+ * Inline sequences
+ */
+inline_seq		: '[' in_inline_seq ']'
+                { 
+                    $$ = $2;
+                }
+				| '[' ']'
+                { 
+                    $$ = syck_alloc_seq();
+                }
+                ;
+
+in_inline_seq   : inline_seq_atom
+                {
+                    $$ = syck_new_seq( syck_hdlr_add_node( (SyckParser *)parser, $1 ) );
+                }
+                | in_inline_seq ',' inline_seq_atom
+				{ 
+                    syck_seq_add( $1, syck_hdlr_add_node( (SyckParser *)parser, $3 ) );
+                    $$ = $1;
+				}
+                ;
+
+inline_seq_atom : atom
+                | basic_mapping
+                ;
+
+/*
+ * Implicit maps
+ */
+implicit_map	: indent_open top_imp_map indent_end
+                { 
+                    apply_seq_in_map( (SyckParser *)parser, $2 );
+                    $$ = $2;
+                }
+                | indent_open in_implicit_map indent_end
+                { 
+                    apply_seq_in_map( (SyckParser *)parser, $2 );
+                    $$ = $2;
+                }
+                ;
+
+top_imp_map     : YAML_TRANSFER indent_sep in_implicit_map
+                { 
+                    syck_add_transfer( $1, $3, ((SyckParser *)parser)->taguri_expansion );
+                    $$ = $3;
+                }
+                | YAML_TRANSFER top_imp_map
+                { 
+                    syck_add_transfer( $1, $2, ((SyckParser *)parser)->taguri_expansion );
+                    $$ = $2;
+                }
+                | YAML_TAGURI indent_sep in_implicit_map
+                { 
+                    syck_add_transfer( $1, $3, 0 );
+                    $$ = $3;
+                }
+                | YAML_TAGURI top_imp_map
+                { 
+                    syck_add_transfer( $1, $2, 0 );
+                    $$ = $2;
+                }
+                | YAML_ANCHOR indent_sep in_implicit_map
+                { 
+                    $$ = syck_hdlr_add_anchor( (SyckParser *)parser, $1, $3 );
+                }
+                | YAML_ANCHOR top_imp_map
+                { 
+                    $$ = syck_hdlr_add_anchor( (SyckParser *)parser, $1, $2 );
+                }
+                ;
+
+complex_key     : word_rep
+                | '?' atom indent_sep
+                {
+                    $$ = $2;
+                }
+                ;
+
+complex_value   : atom_or_empty
+                ;
+
+/* Default needs to be added to SyckSeq i think...
+				| '=' ':' atom
+				{
+					result = [ :DEFAULT, val[2] ]
+				}
+*/
+
+complex_mapping : complex_key ':' complex_value
+                {
+                    $$ = syck_new_map( 
+                        syck_hdlr_add_node( (SyckParser *)parser, $1 ), 
+                        syck_hdlr_add_node( (SyckParser *)parser, $3 ) );
+                }
+/*
+				| '?' atom
+                {
+                    NULL_NODE( parser, n );
+                    $$ = syck_new_map( 
+                        syck_hdlr_add_node( (SyckParser *)parser, $2 ), 
+                        syck_hdlr_add_node( (SyckParser *)parser, n ) );
+                }
+*/
+                ;
+
+in_implicit_map : complex_mapping
+				| in_implicit_map indent_sep basic_seq
+                {
+                    if ( $1->shortcut == NULL )
+                    {
+                        $1->shortcut = syck_new_seq( $3 );
+                    }
+                    else
+                    {
+                        syck_seq_add( $1->shortcut, $3 );
+                    }
+                    $$ = $1;
+                }
+				| in_implicit_map indent_sep complex_mapping
+                {
+                    apply_seq_in_map( (SyckParser *)parser, $1 );
+                    syck_map_update( $1, $3 );
+                    syck_free_node( $3 );
+                    $3 = NULL;
+                    $$ = $1;
+                }
+				| in_implicit_map indent_sep
+                {
+                    $$ = $1;
+                }
+                ;
+
+/*
+ * Inline maps
+ */
+basic_mapping	: atom ':' atom_or_empty
+                {
+                    $$ = syck_new_map( 
+                        syck_hdlr_add_node( (SyckParser *)parser, $1 ), 
+                        syck_hdlr_add_node( (SyckParser *)parser, $3 ) );
+                }
+                ;
+
+inline_map		: '{' in_inline_map '}'
+                {
+                    $$ = $2;
+                }
+          		| '{' '}'
+                {
+                    $$ = syck_alloc_map();
+                }
+                ;
+         
+in_inline_map	: inline_map_atom
+				| in_inline_map ',' inline_map_atom
+				{
+                    syck_map_update( $1, $3 );
+                    syck_free_node( $3 );
+                    $3 = NULL;
+                    $$ = $1;
+				}
+                ;
+
+inline_map_atom : atom
+                {
+                    NULL_NODE( parser, n );
+                    $$ = syck_new_map( 
+                        syck_hdlr_add_node( (SyckParser *)parser, $1 ), 
+                        syck_hdlr_add_node( (SyckParser *)parser, n ) );
+                }
+                | basic_mapping
+                ;
+
+%%
+
+void
+apply_seq_in_map( SyckParser *parser, SyckNode *n )
+{
+    long map_len;
+    if ( n->shortcut == NULL )
+    {
+        return;
+    }
+
+    map_len = syck_map_count( n );
+    syck_map_assign( n, map_value, map_len - 1,
+        syck_hdlr_add_node( parser, n->shortcut ) );
+
+    n->shortcut = NULL;
+}

--- a/syck.gemspec
+++ b/syck.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.license = "MIT"
   s.require_paths = ["lib"]
   s.extensions = ["ext/syck/extconf.rb"]
-  s.files = Dir["[A-Z]*", "ext/**/*", "lib/**/*.rb", "test/**/*.rb"] - %w[Gemfile.lock]
+  s.files = Dir["[A-Z]*", "ext/**/*", "lib/**/*.rb", "test/**/*.rb"] - %w[Gemfile.lock ext/syck/gram.y]
   s.extra_rdoc_files = ["CHANGELOG.rdoc", "README.rdoc"]
   s.test_files = Dir["test/**/*.rb"]
   s.rdoc_options = ["--main", "README.rdoc"]


### PR DESCRIPTION
This commit adds gram.y (with compatibility modifications) from the original syck library by _why found here:
https://github.com/whymirror/syck/blob/master/lib/gram.y

By adding back the original gram.y, it will allow us to make changes to the parser without modifying the autogenerated files.

This commit also generates a new gram.c and gram.h using a newer version of Bison using this command:

    bison gram.y -o gram.c --header=gram.h

Co-Authored-By: Matt Valentine-House <matt@eightbitraptor.com>