### PR TITLE
Make Syck compile with -Werror=incompatible-function-pointer-types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,12 @@ jobs:
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ubuntu-latest, macos-latest]
+        exclude:
+          - { os: macos-latest, ruby: '2.4' }
+          - { os: macos-latest, ruby: '2.5' }
+        include:
+          - { os: macos-13, ruby: '2.4' }
+          - { os: macos-13, ruby: '2.5' }
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/ext/syck/emitter.c
+++ b/ext/syck/emitter.c
@@ -138,9 +138,10 @@ syck_new_emitter(void)
 }
 
 int
-syck_st_free_anchors( char *key, char *name, char *arg )
+syck_st_free_anchors( st_data_t key, st_data_t name, st_data_t arg )
 {
-    S_FREE( name );
+    char *name_as_ptr = (char *)name;
+    S_FREE( name_as_ptr );
     return ST_CONTINUE;
 }
 

--- a/ext/syck/rubyext.c
+++ b/ext/syck/rubyext.c
@@ -322,7 +322,7 @@ mktime_do(VALUE varg)
 }
 
 VALUE
-mktime_r(VALUE varg)
+mktime_r(VALUE varg, VALUE errinfo)
 {
     struct mktime_arg *arg = (struct mktime_arg *)varg;
 
@@ -351,7 +351,13 @@ rb_syck_mktime(const char *str, long len)
  * (see http://www.yaml.org/type/merge/)
  */
 VALUE
-syck_merge_i(VALUE entry, VALUE hsh )
+syck_merge_i(
+#ifdef RB_BLOCK_CALL_FUNC_ARGLIST
+    RB_BLOCK_CALL_FUNC_ARGLIST(entry, hsh)
+#else
+    VALUE entry, VALUE hsh
+#endif
+)
 {
     VALUE tmp;
     if ( !NIL_P(tmp = rb_check_convert_type(entry, T_HASH, "Hash", "to_hash")) )
@@ -733,9 +739,9 @@ syck_set_model(VALUE p, VALUE input, VALUE model)
 }
 
 static int
-syck_st_mark_nodes( char *key, SyckNode *n, char *arg )
+syck_st_mark_nodes( st_data_t key, st_data_t n, st_data_t arg )
 {
-    if ( n != (void *)1 ) syck_node_mark( n );
+    if ( n != 1 ) syck_node_mark( (SyckNode *)n );
     return ST_CONTINUE;
 }
 
@@ -1042,7 +1048,13 @@ syck_resolver_node_import(VALUE self, VALUE node)
  * Set instance variables
  */
 VALUE
-syck_set_ivars(VALUE vars, VALUE obj)
+syck_set_ivars(
+#ifdef RB_BLOCK_CALL_FUNC_ARGLIST
+    RB_BLOCK_CALL_FUNC_ARGLIST(vars, obj)
+#else
+    VALUE vars, VALUE obj
+#endif
+)
 {
     VALUE ivname = rb_ary_entry( vars, 0 );
     char *ivn;

--- a/ext/syck/syck.c
+++ b/ext/syck/syck.c
@@ -201,10 +201,14 @@ syck_lookup_sym( SyckParser *p, SYMID id, void **datap )
 }
 
 int
-syck_st_free_nodes( char *key, SyckNode *n, char *arg )
+syck_st_free_nodes( st_data_t key, st_data_t n, st_data_t arg )
 {
-    if ( n != (void *)1 ) syck_free_node( n );
-    n = NULL;
+    if ( n != 1 ) syck_free_node( (SyckNode *)n );
+    /* Previously, this codde declared the `n` parameter as `SyckNode *`, and this
+     * code said `n = NULL`. That's obviously a no-op, and this code _probably_ should
+     * have said `*n = NULL`. However I'm terrified of actually changing Syck's behaviour
+     * at this juncture, so I'll just adjust the type of the assignment to 0 from NULL. */
+    n = 0;
     return ST_CONTINUE;
 }
 
@@ -238,10 +242,11 @@ typedef struct {
 } bytestring_t;
 
 int
-syck_st_free_syms( void *key, bytestring_t *sav, void *dummy )
+syck_st_free_syms( st_data_t key, st_data_t sav, st_data_t dummy )
 {
-    S_FREE(sav->buffer);
-    S_FREE(sav);
+    bytestring_t *sav_ptr = (bytestring_t *)sav;
+    S_FREE(sav_ptr->buffer);
+    S_FREE(sav_ptr);
     return ST_CONTINUE;
 }
 


### PR DESCRIPTION
New versions of Clang in XCode on MacOS throw a hard error on some of the misuses of function pointer types that Syck commits. Obviously the solution to this problem is to stop using Syck, and we're working on that, but in the meanwhile it would be good if people could `bundle install` applications with Syck without having to add hacks to their bundler configs to override the flags.

Most of this commit is fixing st_hash iterators which should take st_data_t integers as arguments, rather than pointers. There are a couple of places where the arguments to rb_block_call need to be fixed up to use the RB_BLOCK_CALL_FUNC_ARGLIST macro too.