### PR TITLE
Fix out of bounds read

### DIFF
--- a/ext/syck/rubyext.c
+++ b/ext/syck/rubyext.c
@@ -770,7 +770,7 @@ rb_syck_bad_anchor_handler(SyckParser *p, char *a)
 {
     VALUE anchor_name = rb_str_new2( a );
     SyckNode *badanc = syck_new_map( rb_str_new2( "name" ), anchor_name );
-    badanc->type_id = syck_strndup( "tag:ruby.yaml.org,2002:object:YAML::Syck::BadAlias", 53 );
+    badanc->type_id = syck_strndup( "tag:ruby.yaml.org,2002:object:YAML::Syck::BadAlias", 50 );
     return badanc;
 }
 


### PR DESCRIPTION
While working on #54, I found that ASAN flags this line because this function call tries to read 53 bytes of a 50-byte string. That's not right!

You can see this yourself, it's triggered while running the test suite, specifically `test/test_exception.rb`. Thankfully, it has no security implications.

Note: build is blocked on #56 