### PR TITLE
Fix the extension build on current Ruby

### DIFF
--- a/ext/syck/rubyext.c
+++ b/ext/syck/rubyext.c
@@ -94,6 +94,63 @@ struct emitter_xtra {
 };
 
 /*
+ * The untyped Data API (Data_Wrap_Struct / Data_Get_Struct) has been
+ * removed from current Ruby, so every wrapper here uses the TypedData
+ * API and the rb_data_type_t definitions below.
+ */
+
+static void syck_node_mark(SyckNode *n);
+static void syck_mark_parser(SyckParser *parser);
+void rb_syck_free_parser(SyckParser *p);
+static void syck_mark_emitter(SyckEmitter *emitter);
+void rb_syck_free_emitter(SyckEmitter *e);
+
+static const rb_data_type_t syck_parser_type = {
+    "syck/parser",
+    {
+        (void (*)(void *))syck_mark_parser,
+        (void (*)(void *))rb_syck_free_parser,
+        0,
+    },
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY,
+};
+
+static const rb_data_type_t syck_node_type = {
+    "syck/node",
+    {
+        (void (*)(void *))syck_node_mark,
+        (void (*)(void *))syck_free_node,
+        0,
+    },
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY,
+};
+
+/*
+ * Nodes owned by the parser must not be freed by the GC.  syck_node_type
+ * is set as the parent so a single &syck_node_type accepts either kind
+ * of node in the accessors below.
+ */
+static const rb_data_type_t syck_node_type_nofree = {
+    "syck/node",
+    {
+        (void (*)(void *))syck_node_mark,
+        0,
+        0,
+    },
+    &syck_node_type, 0, RUBY_TYPED_FREE_IMMEDIATELY,
+};
+
+static const rb_data_type_t syck_emitter_type = {
+    "syck/emitter",
+    {
+        (void (*)(void *))syck_mark_emitter,
+        (void (*)(void *))rb_syck_free_emitter,
+        0,
+    },
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY,
+};
+
+/*
  * Convert YAML to bytecode
  */
 VALUE
@@ -655,7 +712,7 @@ rb_syck_load_handler(SyckParser *p, SyckNode *n)
     /*
      * Create node,
      */
-    obj = rb_funcall( resolver, s_node_import, 1, Data_Wrap_Struct( cNode, syck_node_mark, NULL, n ) );
+    obj = rb_funcall( resolver, s_node_import, 1, TypedData_Wrap_Struct( cNode, &syck_node_type_nofree, n ) );
 
     /*
      * ID already set, let's alter the symbol table to accept the new object
@@ -712,7 +769,7 @@ void
 syck_set_model(VALUE p, VALUE input, VALUE model)
 {
     SyckParser *parser;
-    Data_Get_Struct(p, SyckParser, parser);
+    TypedData_Get_Struct(p, SyckParser, &syck_parser_type, parser);
     syck_parser_handler( parser, rb_syck_load_handler );
     /* WARN: gonna be obsoleted soon!! */
     if ( model == sym_generic )
@@ -791,7 +848,7 @@ syck_parser_s_alloc(VALUE class)
     parser->bonus = S_ALLOC( struct parser_xtra );
     S_MEMZERO( parser->bonus, struct parser_xtra, 1 );
 
-    pobj = Data_Wrap_Struct( class, syck_mark_parser, rb_syck_free_parser, parser );
+    pobj = TypedData_Wrap_Struct( class, &syck_parser_type, parser );
 
     syck_parser_set_root_on_error( parser, Qnil );
 
@@ -828,7 +885,7 @@ syck_parser_bufsize_set(VALUE self, VALUE size)
 
     if ( rb_respond_to( size, s_to_i ) ) {
         int n = NUM2INT(rb_funcall(size, s_to_i, 0));
-        Data_Get_Struct(self, SyckParser, parser);
+        TypedData_Get_Struct(self, SyckParser, &syck_parser_type, parser);
         parser->bufsize = n;
     }
     return self;
@@ -842,7 +899,7 @@ syck_parser_bufsize_get(VALUE self)
 {
     SyckParser *parser;
 
-    Data_Get_Struct(self, SyckParser, parser);
+    TypedData_Get_Struct(self, SyckParser, &syck_parser_type, parser);
     return INT2FIX( parser->bufsize );
 }
 
@@ -860,7 +917,7 @@ syck_parser_load(int argc, VALUE *argv, VALUE self)
 
     input = rb_hash_aref( rb_attr_get( self, s_options ), sym_input );
     model = rb_hash_aref( rb_attr_get( self, s_options ), sym_model );
-    Data_Get_Struct(self, SyckParser, parser);
+    TypedData_Get_Struct(self, SyckParser, &syck_parser_type, parser);
     syck_set_model( self, input, model );
 
     bonus = (struct parser_xtra *)parser->bonus;
@@ -887,7 +944,7 @@ syck_parser_load_documents(int argc, VALUE *argv, VALUE self)
 
     input = rb_hash_aref( rb_attr_get( self, s_options ), sym_input );
     model = rb_hash_aref( rb_attr_get( self, s_options ), sym_model );
-    Data_Get_Struct(self, SyckParser, parser);
+    TypedData_Get_Struct(self, SyckParser, &syck_parser_type, parser);
     syck_set_model( self, input, model );
 
     bonus = (struct parser_xtra *)parser->bonus;
@@ -973,7 +1030,7 @@ syck_resolver_node_import(VALUE self, VALUE node)
     SyckNode *n;
     VALUE obj = Qnil;
     int i = 0;
-    Data_Get_Struct(node, SyckNode, n);
+    TypedData_Get_Struct(node, SyckNode, &syck_node_type, n);
 
     switch (n->kind)
     {
@@ -1264,7 +1321,7 @@ syck_defaultresolver_node_import(VALUE self, VALUE node)
 {
     SyckNode *n;
     VALUE obj;
-    Data_Get_Struct( node, SyckNode, n );
+    TypedData_Get_Struct( node, SyckNode, &syck_node_type, n );
     if ( !yaml_org_handler( n, &obj ) )
     {
         obj = rb_funcall( self, s_transfer, 2, rb_str_new2( n->type_id ), obj );
@@ -1281,7 +1338,7 @@ syck_genericresolver_node_import(VALUE self, VALUE node)
     SyckNode *n;
     int i = 0;
     VALUE t = Qnil, obj = Qnil, v = Qnil, style = Qnil;
-    Data_Get_Struct(node, SyckNode, n);
+    TypedData_Get_Struct(node, SyckNode, &syck_node_type, n);
 
     if ( n->type_id != NULL )
     {
@@ -1448,7 +1505,7 @@ VALUE
 syck_scalar_alloc(VALUE class)
 {
     SyckNode *node = syck_alloc_str();
-    VALUE obj = Data_Wrap_Struct( class, syck_node_mark, syck_free_node, node );
+    VALUE obj = TypedData_Wrap_Struct( class, &syck_node_type, node );
     node->id = obj;
     return obj;
 }
@@ -1473,7 +1530,7 @@ VALUE
 syck_scalar_style_set(VALUE self, VALUE style)
 {
     SyckNode *node;
-    Data_Get_Struct( self, SyckNode, node );
+    TypedData_Get_Struct( self, SyckNode, &syck_node_type, node );
 
     if ( NIL_P( style ) )
     {
@@ -1511,7 +1568,7 @@ VALUE
 syck_scalar_value_set(VALUE  self, VALUE val)
 {
     SyckNode *node;
-    Data_Get_Struct( self, SyckNode, node );
+    TypedData_Get_Struct( self, SyckNode, &syck_node_type, node );
 
     StringValue( val );
     node->data.str->ptr = syck_strndup( RSTRING_PTR(val), RSTRING_LEN(val) );
@@ -1531,7 +1588,7 @@ syck_seq_alloc(VALUE class)
     SyckNode *node;
     VALUE obj;
     node = syck_alloc_seq();
-    obj = Data_Wrap_Struct( class, syck_node_mark, syck_free_node, node );
+    obj = TypedData_Wrap_Struct( class, &syck_node_type, node );
     node->id = obj;
     return obj;
 }
@@ -1543,7 +1600,7 @@ VALUE
 syck_seq_initialize(VALUE self, VALUE type_id, VALUE val, VALUE style)
 {
     SyckNode *node;
-    Data_Get_Struct( self, SyckNode, node );
+    TypedData_Get_Struct( self, SyckNode, &syck_node_type, node );
 
     rb_iv_set( self, "@kind", sym_seq );
     rb_funcall( self, s_type_id_set, 1, type_id );
@@ -1559,7 +1616,7 @@ VALUE
 syck_seq_value_set(VALUE self, VALUE val)
 {
     SyckNode *node;
-    Data_Get_Struct( self, SyckNode, node );
+    TypedData_Get_Struct( self, SyckNode, &syck_node_type, node );
 
     val = rb_check_array_type( val );
     if ( !NIL_P( val ) ) {
@@ -1583,7 +1640,7 @@ syck_seq_add_m(VALUE self, VALUE val)
 {
     SyckNode *node;
     VALUE emitter = rb_ivar_get( self, s_emitter );
-    Data_Get_Struct( self, SyckNode, node );
+    TypedData_Get_Struct( self, SyckNode, &syck_node_type, node );
 
     if ( rb_respond_to( emitter, s_node_export ) ) {
         val = rb_funcall( emitter, s_node_export, 1, val );
@@ -1601,7 +1658,7 @@ VALUE
 syck_seq_style_set(VALUE self, VALUE style)
 {
     SyckNode *node;
-    Data_Get_Struct( self, SyckNode, node );
+    TypedData_Get_Struct( self, SyckNode, &syck_node_type, node );
 
     if ( style == sym_inline )
     {
@@ -1625,7 +1682,7 @@ syck_map_alloc(VALUE class)
     SyckNode *node;
     VALUE obj;
     node = syck_alloc_map();
-    obj = Data_Wrap_Struct( class, syck_node_mark, syck_free_node, node );
+    obj = TypedData_Wrap_Struct( class, &syck_node_type, node );
     node->id = obj;
     return obj;
 }
@@ -1637,7 +1694,7 @@ VALUE
 syck_map_initialize(VALUE self, VALUE type_id, VALUE val, VALUE style)
 {
     SyckNode *node;
-    Data_Get_Struct( self, SyckNode, node );
+    TypedData_Get_Struct( self, SyckNode, &syck_node_type, node );
 
     if ( !NIL_P( val ) )
     {
@@ -1671,7 +1728,7 @@ VALUE
 syck_map_value_set(VALUE self, VALUE val)
 {
     SyckNode *node;
-    Data_Get_Struct( self, SyckNode, node );
+    TypedData_Get_Struct( self, SyckNode, &syck_node_type, node );
 
     if ( !NIL_P( val ) )
     {
@@ -1704,7 +1761,7 @@ syck_map_add_m(VALUE self, VALUE key, VALUE val)
 {
     SyckNode *node;
     VALUE emitter = rb_ivar_get( self, s_emitter );
-    Data_Get_Struct( self, SyckNode, node );
+    TypedData_Get_Struct( self, SyckNode, &syck_node_type, node );
 
     if ( rb_respond_to( emitter, s_node_export ) ) {
         key = rb_funcall( emitter, s_node_export, 1, key );
@@ -1723,7 +1780,7 @@ VALUE
 syck_map_style_set(VALUE self, VALUE style)
 {
     SyckNode *node;
-    Data_Get_Struct( self, SyckNode, node );
+    TypedData_Get_Struct( self, SyckNode, &syck_node_type, node );
 
     if ( style == sym_inline )
     {
@@ -1756,8 +1813,8 @@ syck_node_init_copy(VALUE copy, VALUE orig)
         rb_raise( rb_eTypeError, "wrong argument type" );
     }
 
-    Data_Get_Struct( orig, SyckNode, orig_n );
-    Data_Get_Struct( copy, SyckNode, copy_n );
+    TypedData_Get_Struct( orig, SyckNode, &syck_node_type, orig_n );
+    TypedData_Get_Struct( copy, SyckNode, &syck_node_type, copy_n );
     MEMCPY( copy_n, orig_n, SyckNode, 1 );
     return copy;
 }
@@ -1770,7 +1827,7 @@ VALUE
 syck_node_type_id_set(VALUE self, VALUE type_id)
 {
     SyckNode *node;
-    Data_Get_Struct( self, SyckNode, node );
+    TypedData_Get_Struct( self, SyckNode, &syck_node_type, node );
 
     S_FREE( node->type_id );
 
@@ -1792,8 +1849,8 @@ syck_node_transform(VALUE self)
     VALUE t;
     SyckNode *n = NULL;
     SyckNode *orig_n;
-    Data_Get_Struct(self, SyckNode, orig_n);
-    t = Data_Wrap_Struct( cNode, syck_node_mark, syck_free_node, 0 );
+    TypedData_Get_Struct(self, SyckNode, &syck_node_type, orig_n);
+    t = TypedData_Wrap_Struct( cNode, &syck_node_type, 0 );
 
     switch (orig_n->kind)
     {
@@ -1846,7 +1903,7 @@ void
 rb_syck_emitter_handler(SyckEmitter *e, st_data_t data)
 {
     SyckNode *n;
-    Data_Get_Struct((VALUE)data, SyckNode, n);
+    TypedData_Get_Struct((VALUE)data, SyckNode, &syck_node_type, n);
 
     switch (n->kind)
     {
@@ -1907,7 +1964,7 @@ syck_out_mark(VALUE emitter, VALUE node)
 {
     SyckEmitter *emitterPtr;
     struct emitter_xtra *bonus;
-    Data_Get_Struct(emitter, SyckEmitter, emitterPtr);
+    TypedData_Get_Struct(emitter, SyckEmitter, &syck_emitter_type, emitterPtr);
     bonus = (struct emitter_xtra *)emitterPtr->bonus;
     rb_ivar_set( node, s_emitter, emitter );
     /* syck_emitter_mark_node( emitterPtr, (st_data_t)node ); */
@@ -1951,7 +2008,7 @@ syck_emitter_s_alloc(VALUE class)
     emitter->bonus = S_ALLOC( struct emitter_xtra );
     S_MEMZERO( emitter->bonus, struct emitter_xtra, 1 );
 
-    pobj = Data_Wrap_Struct( class, syck_mark_emitter, rb_syck_free_emitter, emitter );
+    pobj = TypedData_Wrap_Struct( class, &syck_emitter_type, emitter );
     syck_emitter_handler( emitter, rb_syck_emitter_handler );
     syck_output_handler( emitter, rb_syck_output_handler );
 
@@ -1978,7 +2035,7 @@ syck_emitter_reset(int argc, VALUE *argv, VALUE self)
     SyckEmitter *emitter;
     struct emitter_xtra *bonus;
 
-    Data_Get_Struct(self, SyckEmitter, emitter);
+    TypedData_Get_Struct(self, SyckEmitter, &syck_emitter_type, emitter);
     bonus = (struct emitter_xtra *)emitter->bonus;
 
     bonus->oid = Qnil;
@@ -2024,7 +2081,7 @@ syck_emitter_emit(int argc, VALUE *argv, VALUE self)
     rb_ivar_set(self, s_level, INT2FIX(level));
 
     rb_scan_args(argc, argv, "1&", &oid, &proc);
-    Data_Get_Struct(self, SyckEmitter, emitter);
+    TypedData_Get_Struct(self, SyckEmitter, &syck_emitter_type, emitter);
     bonus = (struct emitter_xtra *)emitter->bonus;
 
     /* Calculate anchors, normalize nodes, build a simpler symbol table */

--- a/ext/syck/rubyext.c
+++ b/ext/syck/rubyext.c
@@ -151,6 +151,18 @@ static const rb_data_type_t syck_emitter_type = {
 };
 
 /*
+ * The taint API (OBJ_TAINT / OBJ_TAINTED) has also been removed from
+ * current Ruby, while older supported versions still provide it; shim
+ * it to a no-op where Ruby no longer defines it.
+ */
+#ifndef OBJ_TAINT
+#define OBJ_TAINT(obj) ((void)(obj))
+#endif
+#ifndef OBJ_TAINTED
+#define OBJ_TAINTED(obj) (0)
+#endif
+
+/*
  * Convert YAML to bytecode
  */
 VALUE

--- a/ext/syck/yaml2byte.c
+++ b/ext/syck/yaml2byte.c
@@ -115,9 +115,7 @@ void bytestring_extend(bytestring_t *str, bytestring_t *ext)
 
 /* convert SyckNode into yamlbyte_buffer_t objects */
 SYMID
-syck_yaml2byte_handler(p, n)
-    SyckParser *p;
-    SyckNode *n;
+syck_yaml2byte_handler(SyckParser *p, SyckNode *n)
 {
     SYMID oid;
     long i;


### PR DESCRIPTION
Current Ruby no longer builds this extension. The untyped Data API (Data_Wrap_Struct and Data_Get_Struct) and the taint API (OBJ_TAINT and OBJ_TAINTED) have both been removed, and extensions are now compiled with -std=gnu23 which rejects old K&R function definitions.

Every wrapper now uses the TypedData API. Parser-owned nodes use a free-less data type whose parent is the node type so a single accessor handles both kinds. OBJ_TAINT and OBJ_TAINTED fall back to no-ops where Ruby no longer defines them. The K&R definition of syck_yaml2byte_handler is rewritten as a prototype.

Verified the build and the full test suite on Ruby head, 3.4, and 2.4.
